### PR TITLE
Add --when and --heading flags to update command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage/
 *private*
 *sensitive*
 *.env*
+backup/

--- a/README.md
+++ b/README.md
@@ -138,17 +138,14 @@ clings tui
 # q/Esc          Quit
 ```
 
-### 8. Shell Integration
+### 8. Shell Completions
 
 Generate shell completions:
 
 ```bash
-clings shell completions bash > ~/.bash_completion.d/clings
-clings shell completions zsh > ~/.zsh/completions/_clings
-clings shell completions fish > ~/.config/fish/completions/clings.fish
-
-# Show installation instructions
-clings shell completions zsh --install
+clings completions bash > ~/.bash_completion.d/clings
+clings completions zsh > ~/.zfunc/_clings
+clings completions fish > ~/.config/fish/completions/clings.fish
 ```
 
 ### 9. Todo Management
@@ -157,24 +154,40 @@ Manage individual todos:
 
 ```bash
 # Show todo details
-clings todo show <ID>
+clings show <ID>
 
 # Update todo properties
-clings todo update <ID> --title "New title"
-clings todo update <ID> --area "Work"
-clings todo update <ID> --project "Sprint 1"
-clings todo update <ID> --when tomorrow --deadline "dec 31"
-clings todo update <ID> --tags "urgent,priority"
+clings update <ID> --name "New title"
+clings update <ID> --notes "Updated notes"
+clings update <ID> --due 2024-12-25
+clings update <ID> --tags work,urgent
+
+# Schedule and organize (requires auth token, see Configuration)
+clings update <ID> --when tomorrow
+clings update <ID> --heading "Waiting on them"
+clings update <ID> --when today --heading "In Progress"
 
 # Mark as complete
-clings todo complete <ID>
+clings complete <ID>          # or: clings done <ID>
 
-# Cancel todo
-clings todo cancel <ID>
-
-# Delete todo
-clings todo delete <ID>
+# Cancel or delete
+clings cancel <ID>
+clings delete <ID>            # or: clings rm <ID>
 ```
+
+### 10. Configuration
+
+Set up the Things 3 auth token for features that use the Things URL scheme (`--when`, `--heading`):
+
+```bash
+# Get your auth token from Things 3:
+# Settings > General > Enable Things URLs > Copy auth token
+
+# Save it to clings
+clings config set-auth-token <your-token>
+```
+
+The auth token is stored at `~/.config/clings/auth-token` with restricted permissions (0600).
 
 ## Requirements
 
@@ -248,23 +261,30 @@ clings add --help
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| `list [VIEW]` | - | List todos from a view (today, inbox, upcoming, etc.) |
-| `today` | `t` | Show today's todos |
+| `today` | `t` | Show today's todos (default) |
 | `inbox` | `i` | Show inbox todos |
 | `upcoming` | `u` | Show upcoming todos |
 | `anytime` | - | Show anytime todos |
 | `someday` | `s` | Show someday todos |
 | `logbook` | `l` | Show completed todos |
 | `add` | `a` | Quick add with natural language |
-| `todo` | - | Manage todos (show, update, complete, cancel, delete) |
-| `project` | - | Manage projects (list, show, add) |
-| `search` | - | Search todos by text or filters |
+| `show` | - | Show details of a todo by ID |
+| `update` | - | Update a todo's properties |
+| `complete` | `done` | Mark a todo as completed |
+| `cancel` | - | Cancel a todo |
+| `delete` | `rm` | Delete a todo (moves to trash) |
+| `search` | `find`, `f` | Search todos by text |
+| `filter` | - | Filter todos using a query expression |
+| `projects` | - | List all projects |
+| `project` | - | Manage projects |
+| `areas` | - | List all areas |
+| `tags` | - | Manage tags |
+| `bulk` | - | Bulk operations on multiple todos |
 | `open` | - | Open Things 3 to a view or item |
-| `bulk` | `b` | Bulk operations on multiple todos |
 | `stats` | - | View productivity statistics |
-| `review` | `r` | Interactive weekly review workflow |
-| `shell` | - | Shell integration (completions) |
-| `tui` | - | Launch the terminal UI |
+| `review` | - | GTD weekly review workflow |
+| `config` | - | Configure clings settings (auth token) |
+| `completions` | - | Generate shell completions |
 
 ## Output Formats
 
@@ -292,6 +312,7 @@ clings today --json | jq '.items[] | select(.tags | contains(["work"]))'
 
 - **Read operations:** Use direct SQLite access to the Things 3 database (read-only)
 - **Write operations:** Use Apple's JavaScript for Automation (JXA) through the official Things 3 API
+- **Scheduling and headings:** Use the Things 3 URL scheme (requires auth token) since `activationDate` is read-only in JXA
 - **No direct database writes:** clings never writes directly to the Things 3 database
 
 ### Best Practices

--- a/Sources/ClingsCLI/Clings.swift
+++ b/Sources/ClingsCLI/Clings.swift
@@ -63,6 +63,7 @@ struct Clings: AsyncParsableCommand {
             StatsCommand.self,
             ReviewCommand.self,
             CompletionsCommand.self,
+            ConfigCommand.self,
         ],
         defaultSubcommand: TodayCommand.self
     )

--- a/Sources/ClingsCLI/Commands/ConfigCommand.swift
+++ b/Sources/ClingsCLI/Commands/ConfigCommand.swift
@@ -1,0 +1,30 @@
+// ConfigCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+
+struct ConfigCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "config",
+        abstract: "Configure clings settings",
+        subcommands: [SetAuthToken.self]
+    )
+}
+
+struct SetAuthToken: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "set-auth-token",
+        abstract: "Set the Things 3 auth token for URL scheme operations (e.g., --heading)"
+    )
+
+    @Argument(help: "The auth token from Things 3 (Settings > General > Enable Things URLs)")
+    var token: String
+
+    func run() throws {
+        try AuthTokenStore.saveToken(token)
+        print("Auth token saved to ~/.config/clings/auth-token")
+    }
+}

--- a/Sources/ClingsCLI/Commands/MutationCommands.swift
+++ b/Sources/ClingsCLI/Commands/MutationCommands.swift
@@ -184,6 +184,8 @@ struct UpdateCommand: AsyncParsableCommand {
           clings update ABC123 --name "New title"
           clings update ABC123 --notes "Updated notes"
           clings update ABC123 --due 2024-12-25
+          clings update ABC123 --when tomorrow
+          clings update ABC123 --heading "Waiting on them"
           clings update ABC123 --tags work,urgent
         """
     )
@@ -200,6 +202,12 @@ struct UpdateCommand: AsyncParsableCommand {
     @Option(name: .long, help: "New due date (YYYY-MM-DD or 'today', 'tomorrow')")
     var due: String?
 
+    @Option(name: .long, help: "Schedule for a date ('today', 'tomorrow', 'evening', 'anytime', 'someday', or YYYY-MM-DD). Requires auth token.")
+    var when: String?
+
+    @Option(name: .long, help: "Move to a heading within the task's project. Requires auth token.")
+    var heading: String?
+
     @Option(name: .long, parsing: .upToNextOption, help: "New tags (replaces existing)")
     var tags: [String] = []
 
@@ -207,8 +215,54 @@ struct UpdateCommand: AsyncParsableCommand {
 
     func run() async throws {
         // Check if any update options provided
-        guard name != nil || notes != nil || due != nil || !tags.isEmpty else {
-            throw ThingsError.invalidState("No update options provided. Use --name, --notes, --due, or --tags.")
+        guard name != nil || notes != nil || due != nil || when != nil || heading != nil || !tags.isEmpty else {
+            throw ThingsError.invalidState("No update options provided. Use --name, --notes, --due, --when, --heading, or --tags.")
+        }
+
+        // Validate --when value if provided
+        if let when = when {
+            let validKeywords = Set(["today", "tomorrow", "evening", "anytime", "someday"])
+            let isKeyword = validKeywords.contains(when.lowercased())
+            let isDate = parseDate(when) != nil
+            guard isKeyword || isDate else {
+                throw ThingsError.invalidState(
+                    "Invalid --when value: '\(when)'. Use 'today', 'tomorrow', 'evening', 'anytime', 'someday', or YYYY-MM-DD."
+                )
+            }
+        }
+
+        // Validate and trim --heading
+        let resolvedHeading: String?
+        if let heading = heading {
+            let trimmed = heading.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw ThingsError.invalidState("--heading value cannot be empty")
+            }
+            guard !trimmed.contains(where: { $0.isNewline }) else {
+                throw ThingsError.invalidState("--heading value cannot contain newlines")
+            }
+            resolvedHeading = trimmed
+        } else {
+            resolvedHeading = nil
+        }
+
+        // Pre-validate auth token before any mutations to avoid partial updates
+        let needsURLScheme = when != nil || resolvedHeading != nil
+        var prevalidatedToken: String? = nil
+        if needsURLScheme {
+            do {
+                prevalidatedToken = try AuthTokenStore.loadToken()
+            } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+                throw ThingsError.invalidState(
+                    "Things auth token required for --when/--heading. Set with: clings config set-auth-token <token>"
+                )
+            } catch let error as ThingsError {
+                throw error
+            } catch {
+                throw ThingsError.operationFailed(
+                    "Failed to read auth token: \(error.localizedDescription). Try re-setting with: clings config set-auth-token <token>"
+                )
+            }
         }
 
         let client = ThingsClientFactory.create()
@@ -222,20 +276,41 @@ struct UpdateCommand: AsyncParsableCommand {
             }
         }
 
-        // Update the todo
-        try await client.updateTodo(
-            id: id,
-            name: name,
-            notes: notes,
-            dueDate: dueDate,
-            tags: tags.isEmpty ? nil : tags
-        )
+        // Update via JXA (name, notes, dueDate, tags)
+        let hasJXAUpdates = name != nil || notes != nil || dueDate != nil || !tags.isEmpty
+        if hasJXAUpdates {
+            try await client.updateTodo(
+                id: id,
+                name: name,
+                notes: notes,
+                dueDate: dueDate,
+                tags: tags.isEmpty ? nil : tags
+            )
+        }
+
+        // Handle when and heading via Things URL scheme (activationDate is read-only in JXA)
+        if needsURLScheme, let token = prevalidatedToken {
+            do {
+                try updateViaURLScheme(id: id, when: when, heading: resolvedHeading, token: token)
+            } catch {
+                if hasJXAUpdates {
+                    let jxaFields = [name != nil ? "name" : nil, notes != nil ? "notes" : nil,
+                                   dueDate != nil ? "due date" : nil, !tags.isEmpty ? "tags" : nil]
+                        .compactMap { $0 }.joined(separator: ", ")
+                    throw ThingsError.operationFailed(
+                        "Partial update: \(jxaFields) updated, but --when/--heading failed: \(error.localizedDescription)"
+                    )
+                }
+                throw error
+            }
+        }
 
         let formatter: OutputFormatter = output.json
             ? JSONOutputFormatter()
             : TextOutputFormatter(useColors: !output.noColor)
 
-        print(formatter.format(message: "Updated todo: \(id)"))
+        let urlSchemeNote = needsURLScheme ? " (--when/--heading sent via URL scheme; verify in Things)" : ""
+        print(formatter.format(message: "Updated todo: \(id)\(urlSchemeNote)"))
     }
 
     private func parseDate(_ str: String) -> Date? {
@@ -254,5 +329,39 @@ struct UpdateCommand: AsyncParsableCommand {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.date(from: str)
+    }
+
+    private func updateViaURLScheme(id: String, when: String?, heading: String?, token: String) throws {
+        var queryItems = [
+            URLQueryItem(name: "auth-token", value: token),
+            URLQueryItem(name: "id", value: id),
+        ]
+        if let when = when {
+            queryItems.append(URLQueryItem(name: "when", value: when.lowercased()))
+        }
+        if let heading = heading {
+            queryItems.append(URLQueryItem(name: "heading", value: heading))
+        }
+
+        guard var components = URLComponents(string: "things:///update") else {
+            throw ThingsError.operationFailed("Internal error: failed to parse Things URL base")
+        }
+        components.queryItems = queryItems
+        guard let url = components.url?.absoluteString else {
+            throw ThingsError.operationFailed("Failed to construct Things URL")
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = [url]
+        do {
+            try process.run()
+        } catch {
+            throw ThingsError.operationFailed("Failed to launch Things URL scheme handler: \(error.localizedDescription)")
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw ThingsError.operationFailed("Failed to update via Things URL scheme (exit code \(process.terminationStatus))")
+        }
     }
 }

--- a/Sources/ClingsCore/Config/AuthTokenStore.swift
+++ b/Sources/ClingsCore/Config/AuthTokenStore.swift
@@ -1,0 +1,73 @@
+// AuthTokenStore.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Manages the Things 3 auth token used for URL scheme operations (e.g., heading updates).
+public enum AuthTokenStore {
+    private static var configDir: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config")
+            .appendingPathComponent("clings")
+    }
+
+    private static var tokenFile: URL {
+        configDir.appendingPathComponent("auth-token")
+    }
+
+    /// Load the stored auth token.
+    public static func loadToken() throws -> String {
+        let token = try String(contentsOf: tokenFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else {
+            throw ThingsError.invalidState("Auth token file is empty")
+        }
+        return token
+    }
+
+    /// Save an auth token to the config directory with restricted permissions (0600).
+    /// Uses POSIX open() to ensure the file is never world-readable, even briefly.
+    public static func saveToken(_ token: String) throws {
+        do {
+            try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        } catch {
+            throw ThingsError.operationFailed(
+                "Failed to create config directory at \(configDir.path): \(error.localizedDescription)"
+            )
+        }
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw ThingsError.invalidState("Auth token cannot be empty")
+        }
+        let tokenData = Data(trimmed.utf8)
+        let path = tokenFile.path
+        let fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0o600)
+        guard fd >= 0 else {
+            let reason = String(cString: strerror(errno))
+            throw ThingsError.operationFailed("Failed to open auth token file at \(path): \(reason)")
+        }
+        defer { close(fd) }
+        // Enforce 0600 even on pre-existing files (open mode only applies on creation)
+        guard fchmod(fd, 0o600) == 0 else {
+            let reason = String(cString: strerror(errno))
+            throw ThingsError.operationFailed("Failed to set permissions on auth token file at \(path): \(reason)")
+        }
+        let written = tokenData.withUnsafeBytes { buffer in
+            guard let base = buffer.baseAddress else { return -1 }
+            return write(fd, base, buffer.count)
+        }
+        let writeErrno = errno // Capture before defer's close() can clobber it
+        guard written == tokenData.count else {
+            if written < 0 {
+                let reason = String(cString: strerror(writeErrno))
+                throw ThingsError.operationFailed("Failed to write auth token to \(path): \(reason)")
+            } else {
+                throw ThingsError.operationFailed(
+                    "Failed to write auth token to \(path): short write (\(written) of \(tokenData.count) bytes)"
+                )
+            }
+        }
+    }
+}

--- a/Tests/ClingsCLITests/ArgumentParsingTests.swift
+++ b/Tests/ClingsCLITests/ArgumentParsingTests.swift
@@ -165,6 +165,32 @@ struct ArgumentParsingTests {
             #expect(command.due == "today")
             #expect(command.tags == ["tag1", "tag2"])
         }
+
+        @Test func whenOption() throws {
+            let command = try UpdateCommand.parse(["JKL012", "--when", "tomorrow"])
+            #expect(command.when == "tomorrow")
+        }
+
+        @Test func whenOptionToday() throws {
+            let command = try UpdateCommand.parse(["JKL012", "--when", "today"])
+            #expect(command.when == "today")
+        }
+
+        @Test func whenOptionDate() throws {
+            let command = try UpdateCommand.parse(["JKL012", "--when", "2026-03-15"])
+            #expect(command.when == "2026-03-15")
+        }
+
+        @Test func headingOption() throws {
+            let command = try UpdateCommand.parse(["JKL012", "--heading", "Waiting on them"])
+            #expect(command.heading == "Waiting on them")
+        }
+
+        @Test func whenAndHeadingTogether() throws {
+            let command = try UpdateCommand.parse(["JKL012", "--when", "today", "--heading", "In Progress"])
+            #expect(command.when == "today")
+            #expect(command.heading == "In Progress")
+        }
     }
 
     @Suite("Add Command")

--- a/Tests/ClingsCoreTests/Config/AuthTokenStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/AuthTokenStoreTests.swift
@@ -1,0 +1,112 @@
+// AuthTokenStoreTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+/// Tests for AuthTokenStore. All tests that mutate the token file
+/// save and restore the original value to avoid clobbering real config.
+@Suite("AuthTokenStore", .serialized)
+struct AuthTokenStoreTests {
+
+    private static let tokenPath = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".config/clings/auth-token")
+
+    /// Read the current token file contents (raw bytes), or nil if missing.
+    private static func backupToken() -> Data? {
+        try? Data(contentsOf: tokenPath)
+    }
+
+    /// Restore the token file to its previous state.
+    private static func restoreToken(_ backup: Data?) {
+        if let backup = backup {
+            try? backup.write(to: tokenPath)
+            // Re-enforce 0600 permissions
+            let fd = open(tokenPath.path, O_WRONLY, 0o600)
+            if fd >= 0 {
+                fchmod(fd, 0o600)
+                close(fd)
+            }
+        } else {
+            try? FileManager.default.removeItem(at: tokenPath)
+        }
+    }
+
+    @Suite("saveToken validation")
+    struct SaveTokenValidation {
+        @Test func rejectsEmptyToken() {
+            #expect(throws: (any Error).self) {
+                try AuthTokenStore.saveToken("")
+            }
+        }
+
+        @Test func rejectsWhitespaceOnlyToken() {
+            #expect(throws: (any Error).self) {
+                try AuthTokenStore.saveToken("   \n\t  ")
+            }
+        }
+    }
+
+    @Suite("saveToken and loadToken round-trip", .serialized)
+    struct RoundTrip {
+        @Test func savesAndLoadsToken() throws {
+            let backup = AuthTokenStoreTests.backupToken()
+            defer { AuthTokenStoreTests.restoreToken(backup) }
+
+            let testToken = "test-token-\(UUID().uuidString)"
+            try AuthTokenStore.saveToken(testToken)
+            let loaded = try AuthTokenStore.loadToken()
+            #expect(loaded == testToken)
+        }
+
+        @Test func trimsWhitespace() throws {
+            let backup = AuthTokenStoreTests.backupToken()
+            defer { AuthTokenStoreTests.restoreToken(backup) }
+
+            let core = "trimmed-token-\(UUID().uuidString)"
+            let testToken = "  \(core)  \n"
+            try AuthTokenStore.saveToken(testToken)
+            let loaded = try AuthTokenStore.loadToken()
+            #expect(loaded == core)
+        }
+
+        @Test func setsRestrictedPermissions() throws {
+            let backup = AuthTokenStoreTests.backupToken()
+            defer { AuthTokenStoreTests.restoreToken(backup) }
+
+            try AuthTokenStore.saveToken("perm-test-\(UUID().uuidString)")
+            let attrs = try FileManager.default.attributesOfItem(atPath: AuthTokenStoreTests.tokenPath.path)
+            let perms = (attrs[.posixPermissions] as? Int) ?? 0
+            #expect(perms == 0o600)
+        }
+
+        @Test func overwritesPreviousToken() throws {
+            let backup = AuthTokenStoreTests.backupToken()
+            defer { AuthTokenStoreTests.restoreToken(backup) }
+
+            let first = "first-\(UUID().uuidString)"
+            let second = "second-\(UUID().uuidString)"
+            try AuthTokenStore.saveToken(first)
+            try AuthTokenStore.saveToken(second)
+            let loaded = try AuthTokenStore.loadToken()
+            #expect(loaded == second)
+        }
+    }
+
+    @Suite("loadToken errors")
+    struct LoadTokenErrors {
+        @Test func throwsWhenTokenFileIsEmpty() throws {
+            let backup = AuthTokenStoreTests.backupToken()
+            defer { AuthTokenStoreTests.restoreToken(backup) }
+
+            // Write an empty file (bypassing saveToken which rejects empty)
+            try Data().write(to: AuthTokenStoreTests.tokenPath)
+            #expect(throws: (any Error).self) {
+                _ = try AuthTokenStore.loadToken()
+            }
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/ThingsClient/JXAScriptsTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/JXAScriptsTests.swift
@@ -243,6 +243,9 @@ struct JXAScriptsTests {
             #expect(script.contains("It\\'s done"))
             #expect(script.contains("Line1\\nLine2"))
         }
+
+        // Note: --when uses Things URL scheme (activationDate is read-only in JXA).
+        // URL scheme tests would require integration testing with Things 3.
     }
 
     @Suite("Create Todo Script")


### PR DESCRIPTION
## Summary

Adds two new flags to `clings update` for scheduling tasks and moving them to project headings:

- `--when` schedules a task (today, tomorrow, evening, anytime, someday, or YYYY-MM-DD)
- `--heading` moves a task to a heading within its project

Both use the Things URL scheme (`things:///update`) since `activationDate` is read-only in JXA. Requires an auth token, managed via a new `clings config set-auth-token` command.

### Usage

```bash
clings config set-auth-token <token>   # One-time setup (from Things > Settings > General)

clings update ABC123 --when tomorrow
clings update ABC123 --heading "In Progress"
clings update ABC123 --when today --heading "Waiting"
clings update ABC123 --name "New title" --when tomorrow
```

## What's included

- **`--when` flag**: Validates against Things URL scheme keywords (today, tomorrow, evening, anytime, someday) plus YYYY-MM-DD dates. Case-insensitive input, normalized to lowercase before dispatch.
- **`--heading` flag**: Validates non-empty, no newlines, trimmed before dispatch.
- **`clings config set-auth-token`**: Stores the Things auth token at `~/.config/clings/auth-token` with 0600 permissions using POSIX `open()` to avoid briefly creating a world-readable file.
- **Auth token pre-validation**: Token is verified before any JXA mutations, preventing partial updates when the token is missing.
- **Partial update reporting**: If JXA fields update but the URL scheme call fails, the error message names which fields already changed.
- **12 new tests**: 5 argument parsing tests for the new flags, 7 AuthTokenStore unit tests (save/load round-trip, permissions, empty rejection, whitespace trimming).
- **README updates** documenting the new flags.

## Design notes

- `activationDate` is read-only in the Things JXA API, so the URL scheme is the only way to set it programmatically.
- The URL scheme is fire-and-forget: `/usr/bin/open` returns success once the URL is dispatched, not when Things processes it. The CLI notes this in the output message.
- POSIX `open()` with `fchmod()` is used instead of `FileManager` to ensure the token file is never world-readable, even briefly.

## Testing

- `swift build` clean
- `swift test`: all new tests pass (14 pre-existing JXA failures on main are unrelated)
- Manual testing: all --when keywords, date formats, --heading values, combined flags, and error/validation paths verified against Things 3