### PR TITLE
[codex] Add productivity workflows, docs, and coverage hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Productivity workflow commands**: Added `views`, `template`, `undo`, `focus`, `pick`, `doctor`, and `project audit` command families to support saved filters, reusable task templates, recent-mutation rollback, focused work queues, interactive follow-up selection, local environment diagnostics, and project health auditing.
+- **Config-backed local state**: Added JSON-backed storage for saved views, templates, undo history, and weekly review session state under the clings config directory.
+- **Command reference and testing docs**: Added `docs/cli/command-reference.md` and `docs/development/testing-and-coverage.md` to document the expanded CLI surface and the source-only Swift Testing coverage workflow.
+
+### Changed
+
+- **CLI help coverage**: Expanded root and subcommand help text with usage guidance and concrete examples across the command tree, and synchronized shell completions with the current top-level and nested commands.
+- **README command reference**: Updated README examples and the command table to reflect the current command surface, including the new productivity workflows and diagnostic tooling.
+- **Weekly review and focus workflows**: Improved review summaries and added richer project/deadline heuristics for more actionable output from review and focus-oriented commands.
+
+### Fixed
+
+- **Coverage target enforcement**: Extended Swift Testing coverage across Things client, JXA bridge, database, NLP, config-store, formatter, and CLI paths so source-only coverage now stays above the 80% project target.
+- **Release docs drift detection**: Adjusted help/completion text and documentation so the release docs check now passes against the expanded CLI surface without false subcommand parsing.
+
 ## [0.3.0] - 2026-03-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ clings show <ID>         # Show details of a specific todo
 Add tasks using natural language parsing:
 
 ```bash
-clings add "publish release notes tomorrow #docs"
-clings add "submit expense report friday 3pm #admin !high"
-clings add "finish report by dec 15 #work"
+clings add "draft changelog entry tomorrow #docs"
+clings add "replace air filter friday 3pm #home !high"
+clings add "finish reading list by dec 15 #reading"
 clings add "review PR // needs careful testing - check auth - verify tests"
 
 # Supported patterns:
@@ -60,13 +60,13 @@ You can also use explicit flags:
 clings add "Task title" \
   --when tomorrow \
   --deadline "2024-12-31" \
-  --tags work urgent \
-  --project "Sprint 1" \
-  --area "Work" \
+  --tags docs urgent \
+  --project "Documentation" \
+  --area "Writing" \
   --notes "Additional context"
 
 # Preview without creating
-clings add "Test task tomorrow #work" --parse-only
+clings add "Test task tomorrow #docs" --parse-only
 ```
 
 ### 3. Search and Filter
@@ -80,8 +80,8 @@ clings find "project report"     # alias for search
 clings f "status"                # short alias
 
 # Save and reuse named views
-clings views save work-today "area = 'Work' AND due <= today"
-clings views run work-today
+clings views save docs-today "tags CONTAINS 'docs' AND due <= today"
+clings views run docs-today
 clings views list
 
 # Advanced filtering (SQL-like query language)
@@ -110,7 +110,7 @@ clings show <ID>
 # Interactive pick flows
 clings pick show report
 clings pick complete release
-clings pick cancel "follow up"
+clings pick cancel cleanup
 
 # Update properties
 clings update <ID> --name "New title"
@@ -143,14 +143,14 @@ clings bulk complete --where "tags CONTAINS 'done'" --dry-run
 # Complete matching tasks
 clings bulk complete --where "tags CONTAINS 'done'"
 
-# Cancel old project tasks
-clings bulk cancel --where "project = 'Old Project'"
+# Cancel archive prep tasks
+clings bulk cancel --where "project = 'Archive Prep'"
 
-# Tag work tasks as urgent
-clings bulk tag "urgent,priority" --where "project = 'Work'"
+# Tag matching tasks as urgent
+clings bulk tag "urgent,priority" --where "tags CONTAINS 'docs'"
 
 # Move tasks to a project
-clings bulk move --where "tags CONTAINS 'work'" --to "Operations Project"
+clings bulk move --where "tags CONTAINS 'draft'" --to "Archive"
 ```
 
 **Safety options:**
@@ -223,7 +223,7 @@ Save reusable task blueprints with tags, notes, checklist items, and relative sc
 
 ```bash
 clings template save weekly-review "Weekly review" \
-  --project "Operations" \
+  --project "Documentation" \
   --when "tomorrow morning" \
   --checklist "Process inbox" "Review deadlines"
 
@@ -275,11 +275,11 @@ cp .build/release/clings /usr/local/bin/
 clings today
 
 # Add a quick task
-clings add "publish release notes tomorrow #docs"
+clings add "draft changelog entry tomorrow #docs"
 
 # Save and run a reusable view
-clings views save urgent-work "area = 'Work' AND tags CONTAINS 'urgent'"
-clings views run urgent-work
+clings views save docs-today "tags CONTAINS 'docs' AND due <= today"
+clings views run docs-today
 
 # Save and reuse a template
 clings template save weekly-review "Weekly review" --when "tomorrow morning"
@@ -365,9 +365,9 @@ Human-readable colored output:
 ```
 Today (3 items)
 ──────────────────────────────────────────────
-[ ] Review PR #123        Development   Dec 15   #work
-[ ] Review release notes  Docs          Dec 15   #work
-[x] Close audit findings  Ops           Dec 10   -
+[ ] Review PR #123        Development   Dec 15   #code
+[ ] Draft changelog entry Docs          Dec 15   #docs
+[x] Archive old notes    Archive       Dec 10   -
 ```
 
 ### JSON
@@ -375,7 +375,7 @@ Today (3 items)
 Machine-readable JSON for scripting:
 
 ```bash
-clings today --json | jq '.items[] | select(.tags | contains(["work"]))'
+clings today --json | jq '.items[] | select(.tags | contains(["docs"]))'
 ```
 
 ## Data Safety

--- a/README.md
+++ b/README.md
@@ -79,12 +79,20 @@ clings search "meeting"
 clings find "project report"     # alias for search
 clings f "status"                # short alias
 
+# Save and reuse named views
+clings views save work-today "area = 'Work' AND due <= today"
+clings views run work-today
+clings views list
+
 # Advanced filtering (SQL-like query language)
 clings filter "status = open"
 clings filter "due < today AND status = open"
 clings filter "tags CONTAINS 'urgent'"
 clings filter "name LIKE '%report%'"
 clings filter "project IS NOT NULL"
+
+# Custom todo-line formatting
+clings today --format "{status} {name} [{project}] {tags}"
 ```
 
 **Filter operators:** `=`, `!=`, `<`, `>`, `<=`, `>=`, `LIKE`, `CONTAINS`, `IS NULL`, `IS NOT NULL`, `IN`
@@ -99,6 +107,11 @@ Manage individual todos:
 # Show details
 clings show <ID>
 
+# Interactive pick flows
+clings pick show report
+clings pick complete release
+clings pick cancel "follow up"
+
 # Update properties
 clings update <ID> --name "New title"
 clings update <ID> --notes "Updated notes"
@@ -111,6 +124,10 @@ clings complete --title "milk"   # complete by title search
 clings cancel <ID>
 clings delete <ID>               # or: clings rm <ID>
 clings delete <ID> --force       # skip confirmation
+
+# Undo supported recent changes
+clings undo
+clings undo --show
 ```
 
 ### 5. Bulk Operations
@@ -130,7 +147,7 @@ clings bulk complete --where "tags CONTAINS 'done'"
 clings bulk cancel --where "project = 'Old Project'"
 
 # Tag work tasks as urgent
-clings bulk tag --where "project = 'Work'" urgent priority
+clings bulk tag "urgent,priority" --where "project = 'Work'"
 
 # Move tasks to a project
 clings bulk move --where "tags CONTAINS 'work'" --to "Operations Project"
@@ -150,6 +167,11 @@ clings stats              # Show dashboard
 clings stats trends       # Completion trends over time
 clings stats heatmap      # Activity heatmap calendar
 clings stats --days 7     # Limit to last 7 days
+
+# Focus mode
+clings focus
+clings focus --limit 5
+clings focus --format "{name} [{project}]"
 ```
 
 ### 7. Weekly Review
@@ -161,6 +183,10 @@ clings review             # Start a new review (default)
 clings review start       # Same as above
 clings review status      # Show last review session info
 clings review clear       # Clear review session
+
+# Audit open projects for stalled work
+clings project audit
+clings project audit --json
 ```
 
 ### 8. Shell Completions
@@ -183,9 +209,30 @@ Set up the Things 3 auth token for features that use the Things URL scheme (`--w
 
 # Save it to clings
 clings config set-auth-token <your-token>
+
+# Diagnose local setup
+clings doctor
+clings doctor --verbose
 ```
 
 The auth token is stored at `~/.config/clings/auth-token` with restricted permissions (0600).
+
+### 10. Templates
+
+Save reusable task blueprints with tags, notes, checklist items, and relative schedule expressions:
+
+```bash
+clings template save weekly-review "Weekly review" \
+  --project "Operations" \
+  --when "tomorrow morning" \
+  --checklist "Process inbox" "Review deadlines"
+
+clings template list
+clings template run weekly-review
+
+# You can also combine a template with an explicit add command
+clings add "Weekly review prep" --template weekly-review
+```
 
 ## Requirements
 
@@ -230,6 +277,14 @@ clings today
 # Add a quick task
 clings add "publish release notes tomorrow #docs"
 
+# Save and run a reusable view
+clings views save urgent-work "area = 'Work' AND tags CONTAINS 'urgent'"
+clings views run urgent-work
+
+# Save and reuse a template
+clings template save weekly-review "Weekly review" --when "tomorrow morning"
+clings template run weekly-review
+
 # View your inbox
 clings inbox
 
@@ -241,6 +296,12 @@ clings filter "due < today AND status = open"
 
 # Get productivity stats
 clings stats
+
+# See your working queue
+clings focus
+
+# Check local setup
+clings doctor
 
 # Get help on any command
 clings --help
@@ -257,6 +318,7 @@ Most output-oriented subcommands support:
 ```
 --json                   Output as JSON (for scripting)
 --no-color               Suppress color output
+--format "{name} ..."    Custom todo-line formatting on todo-list commands
 ```
 
 ### Commands
@@ -276,6 +338,12 @@ Most output-oriented subcommands support:
 | `cancel` | - | Cancel a todo |
 | `delete` | `rm` | Delete a todo (moves to trash) |
 | `search` | `find`, `f` | Search todos by text |
+| `views` | - | Manage saved filter views |
+| `template` | - | Manage reusable task templates |
+| `undo` | - | Undo the most recent supported mutation |
+| `focus` | - | Show a focused queue of high-attention tasks |
+| `pick` | - | Interactively pick a todo for a follow-up action |
+| `doctor` | - | Check clings setup and local environment |
 | `filter` | - | Filter todos using a query expression |
 | `projects` | - | List all projects |
 | `project` | - | Manage projects |

--- a/Sources/ClingsCLI/Clings.swift
+++ b/Sources/ClingsCLI/Clings.swift
@@ -15,10 +15,15 @@ struct Clings: AsyncParsableCommand {
         discussion: """
         clings provides fast, scriptable access to Things 3 from the command line.
 
-        QUICK START:
+        USAGE:
+          clings <subcommand> [options]
+
+        EXAMPLES:
           clings today              Show today's todos
           clings inbox              Show inbox
-          clings add "Review release checklist"     Add a new todo
+          clings add "Review release checklist tomorrow #docs"
+          clings views run work-today
+          clings doctor --verbose
 
         OUTPUT FORMATS:
           --json                    Machine-readable JSON for scripting
@@ -51,6 +56,12 @@ struct Clings: AsyncParsableCommand {
             DeleteCommand.self,
             UpdateCommand.self,
             SearchCommand.self,
+            ViewsCommand.self,
+            TemplateCommand.self,
+            UndoCommand.self,
+            FocusCommand.self,
+            PickCommand.self,
+            DoctorCommand.self,
 
             // Bulk operations
             BulkCommand.self,

--- a/Sources/ClingsCLI/Clings.swift
+++ b/Sources/ClingsCLI/Clings.swift
@@ -21,8 +21,8 @@ struct Clings: AsyncParsableCommand {
         EXAMPLES:
           clings today              Show today's todos
           clings inbox              Show inbox
-          clings add "Review release checklist tomorrow #docs"
-          clings views run work-today
+          clings add "Draft changelog entry tomorrow #docs"
+          clings views run docs-today
           clings doctor --verbose
 
         OUTPUT FORMATS:

--- a/Sources/ClingsCLI/Commands/AddCommand.swift
+++ b/Sources/ClingsCLI/Commands/AddCommand.swift
@@ -16,9 +16,9 @@ struct AddCommand: AsyncParsableCommand {
         and checklist items.
 
         EXAMPLES:
-          clings add "Finalize release notes tomorrow #docs"
-          clings add "Submit expense report by friday !!"
-          clings add "Review deployment guide for Migration Project"
+          clings add "Draft changelog entry tomorrow #docs"
+          clings add "Replace air filter by friday !!"
+          clings add "Review chapter outline for Writing Project"
           clings add "Task // notes go here"
           clings add "Task - checklist item 1 - checklist item 2"
         """

--- a/Sources/ClingsCLI/Commands/AddCommand.swift
+++ b/Sources/ClingsCLI/Commands/AddCommand.swift
@@ -12,7 +12,10 @@ struct AddCommand: AsyncParsableCommand {
         commandName: "add",
         abstract: "Add a new todo with natural language support",
         discussion: """
-        Supports natural language patterns:
+        Supports natural language patterns for capture, scheduling, tags, notes,
+        and checklist items.
+
+        EXAMPLES:
           clings add "Finalize release notes tomorrow #docs"
           clings add "Submit expense report by friday !!"
           clings add "Review deployment guide for Migration Project"
@@ -23,6 +26,9 @@ struct AddCommand: AsyncParsableCommand {
 
     @Argument(help: "The todo title (supports natural language)")
     var title: String
+
+    @Option(name: .long, help: "Start from a saved task template")
+    var template: String?
 
     @Option(name: .long, help: "Add notes to the todo")
     var notes: String?
@@ -49,7 +55,50 @@ struct AddCommand: AsyncParsableCommand {
 
     func run() async throws {
         let parser = TaskParser()
-        var parsed = parser.parse(title)
+        var parsed = ParsedTask(title: "")
+
+        if let template {
+            guard let savedTemplate = try TemplateStore.load(name: template) else {
+                throw ValidationError("Template not found: \(template)")
+            }
+
+            parsed = ParsedTask(
+                title: savedTemplate.title,
+                notes: savedTemplate.notes,
+                tags: savedTemplate.tags,
+                project: savedTemplate.project,
+                area: savedTemplate.area,
+                dueDate: parseFlexibleDate(savedTemplate.deadlineExpression),
+                whenDate: parseFlexibleDate(savedTemplate.whenExpression),
+                checklistItems: savedTemplate.checklistItems
+            )
+        }
+
+        let titleParsed = parser.parse(title)
+        if !titleParsed.title.isEmpty {
+            parsed.title = titleParsed.title
+        }
+        if let parsedNotes = titleParsed.notes, !parsedNotes.isEmpty {
+            parsed.notes = parsedNotes
+        }
+        if !titleParsed.tags.isEmpty {
+            parsed.tags.append(contentsOf: titleParsed.tags)
+        }
+        if let parsedProject = titleParsed.project {
+            parsed.project = parsedProject
+        }
+        if let parsedArea = titleParsed.area {
+            parsed.area = parsedArea
+        }
+        if let parsedWhen = titleParsed.whenDate {
+            parsed.whenDate = parsedWhen
+        }
+        if let parsedDue = titleParsed.dueDate {
+            parsed.dueDate = parsedDue
+        }
+        if !titleParsed.checklistItems.isEmpty {
+            parsed.checklistItems = titleParsed.checklistItems
+        }
 
         // Command line options override parsed values
         if let notes = notes {
@@ -65,11 +114,13 @@ struct AddCommand: AsyncParsableCommand {
             parsed.area = area
         }
         if let when = when {
-            parsed.whenDate = parseSimpleDate(when)
+            parsed.whenDate = parseFlexibleDate(when)
         }
         if let deadline = deadline {
-            parsed.dueDate = parseSimpleDate(deadline)
+            parsed.dueDate = parseFlexibleDate(deadline)
         }
+
+        parsed.tags = Array(NSOrderedSet(array: parsed.tags)) as? [String] ?? parsed.tags
 
         // Handle parse-only mode
         if parseOnly {
@@ -77,8 +128,8 @@ struct AddCommand: AsyncParsableCommand {
             return
         }
 
-        let client = ThingsClientFactory.create()
-        _ = try await client.createTodo(
+        let client = CommandRuntime.makeClient()
+        let id = try await client.createTodo(
             name: parsed.title,
             notes: parsed.notes,
             when: parsed.whenDate,
@@ -88,26 +139,9 @@ struct AddCommand: AsyncParsableCommand {
             area: parsed.area,
             checklistItems: parsed.checklistItems
         )
+        try UndoStore.record(UndoEntry(operation: .create, todoID: id, snapshot: nil))
 
-        let outputFormatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(outputFormatter.format(message: "Created: \(parsed.title)"))
-    }
-
-    private func parseSimpleDate(_ str: String) -> Date? {
-        let calendar = Calendar.current
-        let now = Date()
-        let lower = str.lowercased()
-
-        if lower == "today" {
-            return calendar.startOfDay(for: now)
-        }
-        if lower == "tomorrow" {
-            return calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
-        }
-        return nil
+        print(renderMessage("Created: \(parsed.title)", output: output))
     }
 
     private func printParsedResult(_ parsed: ParsedTask) {

--- a/Sources/ClingsCLI/Commands/BulkCommand.swift
+++ b/Sources/ClingsCLI/Commands/BulkCommand.swift
@@ -22,7 +22,7 @@ struct BulkCommand: AsyncParsableCommand {
         EXAMPLES:
           clings bulk complete --where "tags CONTAINS 'done'"
           clings bulk cancel --list inbox --dry-run
-          clings bulk move --to "Archive" --where "status = open"
+          clings bulk move --to "Archive" --where "tags CONTAINS 'draft'"
 
         SEE ALSO:
           filter, complete, cancel
@@ -147,7 +147,7 @@ struct BulkCancelCommand: AsyncParsableCommand {
 
         EXAMPLES:
           clings bulk cancel --list inbox
-          clings bulk cancel --where "status = open AND project IS NULL"
+          clings bulk cancel --where "status = open AND tags CONTAINS 'cleanup'"
           clings bulk cancel --dry-run
 
         SEE ALSO:
@@ -310,7 +310,7 @@ struct BulkMoveCommand: AsyncParsableCommand {
         Moves multiple todos to a project based on filter criteria.
 
         EXAMPLES:
-          clings bulk move --to "Operations Project" --list inbox
+          clings bulk move --to "Archive" --list inbox
           clings bulk move --to "Archive" --where "tags CONTAINS 'done'"
           clings bulk move --to "Backlog" --dry-run
 

--- a/Sources/ClingsCLI/Commands/BulkCommand.swift
+++ b/Sources/ClingsCLI/Commands/BulkCommand.swift
@@ -76,7 +76,7 @@ struct BulkCompleteCommand: AsyncParsableCommand {
     var list: String = "today"
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
 
         // Get list view
         guard let listView = ListView(rawValue: list.lowercased()) else {
@@ -114,7 +114,7 @@ struct BulkCompleteCommand: AsyncParsableCommand {
         // Confirm unless --yes
         if !bulkOptions.yes {
             print("\nProceed? (y/N): ", terminator: "")
-            guard let response = readLine(), response.lowercased() == "y" else {
+            guard let response = CommandRuntime.inputReader(), response.lowercased() == "y" else {
                 print(formatter.format(message: "Aborted"))
                 return
             }
@@ -161,7 +161,7 @@ struct BulkCancelCommand: AsyncParsableCommand {
     var list: String = "today"
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
 
         guard let listView = ListView(rawValue: list.lowercased()) else {
             throw ThingsError.invalidState("Unknown list: \(list)")
@@ -194,7 +194,7 @@ struct BulkCancelCommand: AsyncParsableCommand {
 
         if !bulkOptions.yes {
             print("\nProceed? (y/N): ", terminator: "")
-            guard let response = readLine(), response.lowercased() == "y" else {
+            guard let response = CommandRuntime.inputReader(), response.lowercased() == "y" else {
                 print(formatter.format(message: "Aborted"))
                 return
             }
@@ -246,7 +246,7 @@ struct BulkTagCommand: AsyncParsableCommand {
     var list: String = "today"
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
 
         guard let listView = ListView(rawValue: list.lowercased()) else {
             throw ThingsError.invalidState("Unknown list: \(list)")
@@ -281,7 +281,7 @@ struct BulkTagCommand: AsyncParsableCommand {
 
         if !bulkOptions.yes {
             print("\nProceed? (y/N): ", terminator: "")
-            guard let response = readLine(), response.lowercased() == "y" else {
+            guard let response = CommandRuntime.inputReader(), response.lowercased() == "y" else {
                 print(formatter.format(message: "Aborted"))
                 return
             }
@@ -328,7 +328,7 @@ struct BulkMoveCommand: AsyncParsableCommand {
     var list: String = "today"
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
 
         guard let listView = ListView(rawValue: list.lowercased()) else {
             throw ThingsError.invalidState("Unknown list: \(list)")
@@ -361,7 +361,7 @@ struct BulkMoveCommand: AsyncParsableCommand {
 
         if !bulkOptions.yes {
             print("\nProceed? (y/N): ", terminator: "")
-            guard let response = readLine(), response.lowercased() == "y" else {
+            guard let response = CommandRuntime.inputReader(), response.lowercased() == "y" else {
                 print(formatter.format(message: "Aborted"))
                 return
             }

--- a/Sources/ClingsCLI/Commands/CompletionsCommand.swift
+++ b/Sources/ClingsCLI/Commands/CompletionsCommand.swift
@@ -12,7 +12,7 @@ struct CompletionsCommand: ParsableCommand {
         discussion: """
         Generate shell completion scripts for bash, zsh, or fish.
 
-        Installation:
+        EXAMPLES:
           bash:  clings completions bash > ~/.bash_completion.d/clings
           zsh:   clings completions zsh > ~/.zfunc/_clings
           fish:  clings completions fish > ~/.config/fish/completions/clings.fish
@@ -53,13 +53,13 @@ struct CompletionsCommand: ParsableCommand {
             prev="${COMP_WORDS[COMP_CWORD-1]}"
 
             # Main commands
-            local commands="today inbox upcoming anytime someday logbook projects project areas tags show add complete cancel delete update search bulk filter open stats review completions config"
+            local commands="today inbox upcoming anytime someday logbook projects project areas tags show add complete cancel delete update search views template undo focus pick doctor bulk filter open stats review completions config"
 
             # Bulk subcommands
             local bulk_commands="complete cancel tag move"
 
             # Project subcommands
-            local project_commands="list add"
+            local project_commands="list add audit"
 
             # Tag subcommands
             local tag_commands="list add delete rename"
@@ -69,6 +69,15 @@ struct CompletionsCommand: ParsableCommand {
 
             # Stats subcommands
             local stats_commands="trends heatmap"
+
+            # Views subcommands
+            local views_commands="list save run delete"
+
+            # Template subcommands
+            local template_commands="list save run delete"
+
+            # Pick subcommands
+            local pick_commands="show complete cancel delete"
 
             case "${prev}" in
                 clings)
@@ -93,6 +102,18 @@ struct CompletionsCommand: ParsableCommand {
                     ;;
                 stats)
                     COMPREPLY=( $(compgen -W "${stats_commands}" -- ${cur}) )
+                    return 0
+                    ;;
+                views)
+                    COMPREPLY=( $(compgen -W "${views_commands}" -- ${cur}) )
+                    return 0
+                    ;;
+                template)
+                    COMPREPLY=( $(compgen -W "${template_commands}" -- ${cur}) )
+                    return 0
+                    ;;
+                pick)
+                    COMPREPLY=( $(compgen -W "${pick_commands}" -- ${cur}) )
                     return 0
                     ;;
                 completions)
@@ -142,6 +163,12 @@ struct CompletionsCommand: ParsableCommand {
                 'delete:Delete a todo'
                 'update:Update a todo'
                 'search:Search todos'
+                'views:Manage saved filter views'
+                'template:Manage reusable task templates'
+                'undo:Undo the most recent supported mutation'
+                'focus:Show a focused queue of high-attention tasks'
+                'pick:Interactively pick a todo for a follow-up action'
+                'doctor:Check clings setup and local environment'
                 'bulk:Bulk operations'
                 'filter:Filter todos'
                 'open:Open in Things (currently disabled)'
@@ -170,6 +197,7 @@ struct CompletionsCommand: ParsableCommand {
             project_commands=(
                 'list:List all projects'
                 'add:Create a new project'
+                'audit:Audit project health and missing next actions'
             )
 
             local -a tag_commands
@@ -184,6 +212,30 @@ struct CompletionsCommand: ParsableCommand {
             stats_commands=(
                 'trends:Show completion trends over time'
                 'heatmap:Show contribution heatmap'
+            )
+
+            local -a views_commands
+            views_commands=(
+                'list:List saved views'
+                'save:Save a named filter view'
+                'run:Run a saved filter view'
+                'delete:Delete a saved view'
+            )
+
+            local -a template_commands
+            template_commands=(
+                'list:List saved templates'
+                'save:Save a task template'
+                'run:Create a task from a template'
+                'delete:Delete a template'
+            )
+
+            local -a pick_commands
+            pick_commands=(
+                'show:Interactively pick a todo to inspect'
+                'complete:Interactively pick a todo to complete'
+                'cancel:Interactively pick a todo to cancel'
+                'delete:Interactively pick a todo to delete'
             )
 
             local -a config_commands
@@ -216,6 +268,15 @@ struct CompletionsCommand: ParsableCommand {
                             ;;
                         stats)
                             _describe 'stats command' stats_commands
+                            ;;
+                        views)
+                            _describe 'views command' views_commands
+                            ;;
+                        template)
+                            _describe 'template command' template_commands
+                            ;;
+                        pick)
+                            _describe 'pick command' pick_commands
                             ;;
                         config)
                             _describe 'config command' config_commands
@@ -257,6 +318,12 @@ struct CompletionsCommand: ParsableCommand {
         complete -c clings -n "__fish_use_subcommand" -a "delete" -d "Delete a todo"
         complete -c clings -n "__fish_use_subcommand" -a "update" -d "Update a todo"
         complete -c clings -n "__fish_use_subcommand" -a "search" -d "Search todos"
+        complete -c clings -n "__fish_use_subcommand" -a "views" -d "Manage saved filter views"
+        complete -c clings -n "__fish_use_subcommand" -a "template" -d "Manage reusable task templates"
+        complete -c clings -n "__fish_use_subcommand" -a "undo" -d "Undo the most recent supported mutation"
+        complete -c clings -n "__fish_use_subcommand" -a "focus" -d "Show a focused queue of high-attention tasks"
+        complete -c clings -n "__fish_use_subcommand" -a "pick" -d "Interactively pick a todo for a follow-up action"
+        complete -c clings -n "__fish_use_subcommand" -a "doctor" -d "Check clings setup and local environment"
         complete -c clings -n "__fish_use_subcommand" -a "bulk" -d "Bulk operations"
         complete -c clings -n "__fish_use_subcommand" -a "filter" -d "Filter todos"
         complete -c clings -n "__fish_use_subcommand" -a "open" -d "Open in Things (currently disabled)"
@@ -274,12 +341,31 @@ struct CompletionsCommand: ParsableCommand {
         # Project subcommands
         complete -c clings -n "__fish_seen_subcommand_from project" -a "list" -d "List all projects"
         complete -c clings -n "__fish_seen_subcommand_from project" -a "add" -d "Create a new project"
+        complete -c clings -n "__fish_seen_subcommand_from project" -a "audit" -d "Audit project health and missing next actions"
 
         # Tag subcommands
         complete -c clings -n "__fish_seen_subcommand_from tags" -a "list" -d "List all tags"
         complete -c clings -n "__fish_seen_subcommand_from tags" -a "add" -d "Create a new tag"
         complete -c clings -n "__fish_seen_subcommand_from tags" -a "delete" -d "Delete a tag"
         complete -c clings -n "__fish_seen_subcommand_from tags" -a "rename" -d "Rename a tag"
+
+        # Views subcommands
+        complete -c clings -n "__fish_seen_subcommand_from views" -a "list" -d "List saved views"
+        complete -c clings -n "__fish_seen_subcommand_from views" -a "save" -d "Save a named filter view"
+        complete -c clings -n "__fish_seen_subcommand_from views" -a "run" -d "Run a saved filter view"
+        complete -c clings -n "__fish_seen_subcommand_from views" -a "delete" -d "Delete a saved view"
+
+        # Template subcommands
+        complete -c clings -n "__fish_seen_subcommand_from template" -a "list" -d "List saved templates"
+        complete -c clings -n "__fish_seen_subcommand_from template" -a "save" -d "Save a task template"
+        complete -c clings -n "__fish_seen_subcommand_from template" -a "run" -d "Create a task from a template"
+        complete -c clings -n "__fish_seen_subcommand_from template" -a "delete" -d "Delete a template"
+
+        # Pick subcommands
+        complete -c clings -n "__fish_seen_subcommand_from pick" -a "show" -d "Interactively pick a todo to inspect"
+        complete -c clings -n "__fish_seen_subcommand_from pick" -a "complete" -d "Interactively pick a todo to complete"
+        complete -c clings -n "__fish_seen_subcommand_from pick" -a "cancel" -d "Interactively pick a todo to cancel"
+        complete -c clings -n "__fish_seen_subcommand_from pick" -a "delete" -d "Interactively pick a todo to delete"
 
         # Review subcommands
         complete -c clings -n "__fish_seen_subcommand_from review" -a "start" -d "Start or resume a weekly review"

--- a/Sources/ClingsCLI/Commands/ConfigCommand.swift
+++ b/Sources/ClingsCLI/Commands/ConfigCommand.swift
@@ -26,7 +26,15 @@ struct ConfigCommand: ParsableCommand {
 struct SetAuthToken: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "set-auth-token",
-        abstract: "Set the Things 3 auth token for URL scheme operations (e.g., --heading)"
+        abstract: "Set the Things 3 auth token for URL scheme operations (e.g., --heading)",
+        discussion: """
+        Save the Things URL auth token locally so URL-scheme features can run
+        without prompting for the token each time.
+
+        EXAMPLES:
+          clings config set-auth-token <token>
+          clings doctor --verbose
+        """
     )
 
     @Argument(help: "The auth token from Things 3 (Settings > General > Enable Things URLs)")

--- a/Sources/ClingsCLI/Commands/DoctorCommand.swift
+++ b/Sources/ClingsCLI/Commands/DoctorCommand.swift
@@ -1,0 +1,101 @@
+// DoctorCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+
+struct DoctorCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "doctor",
+        abstract: "Check clings setup and local environment",
+        discussion: """
+        Run local diagnostics for config storage, database access, automation
+        runtime availability, and auth-token configuration.
+
+        EXAMPLES:
+          clings doctor
+          clings doctor --verbose
+          clings doctor --json
+        """
+    )
+
+    @Flag(name: .long, help: "Include paths and extra detail")
+    var verbose = false
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+        let report = DoctorReport.generate(verbose: verbose)
+
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(report)
+            print(String(data: data, encoding: .utf8) ?? "{}")
+            return
+        }
+
+        print("clings doctor")
+        print("─────────────────────────────────────")
+        for check in report.checks {
+            let marker = check.status == "ok" ? "✓" : "!"
+            print("\(marker) \(check.name): \(check.message)")
+            if verbose, let detail = check.detail {
+                print("  \(detail)")
+            }
+        }
+        print("")
+        print("Overall: \(report.overallStatus)")
+    }
+}
+
+private struct DoctorReport: Codable {
+    let overallStatus: String
+    let checks: [DoctorCheck]
+
+    static func generate(verbose: Bool) -> DoctorReport {
+        var checks: [DoctorCheck] = []
+
+        do {
+            let configDir = try ClingsConfig.ensureDirectory()
+            checks.append(DoctorCheck(name: "Config directory", status: "ok", message: "Writable", detail: verbose ? configDir.path : nil))
+        } catch {
+            checks.append(DoctorCheck(name: "Config directory", status: "warning", message: error.localizedDescription, detail: nil))
+        }
+
+        do {
+            let _ = try CommandRuntime.makeDatabase()
+            checks.append(DoctorCheck(name: "Things database", status: "ok", message: "Readable", detail: nil))
+        } catch {
+            checks.append(DoctorCheck(name: "Things database", status: "warning", message: error.localizedDescription, detail: nil))
+        }
+
+        let osascriptPath = "/usr/bin/osascript"
+        if FileManager.default.fileExists(atPath: osascriptPath) {
+            checks.append(DoctorCheck(name: "Automation runtime", status: "ok", message: "osascript available", detail: verbose ? osascriptPath : nil))
+        } else {
+            checks.append(DoctorCheck(name: "Automation runtime", status: "warning", message: "osascript missing", detail: nil))
+        }
+
+        do {
+            _ = try AuthTokenStore.loadToken()
+            checks.append(DoctorCheck(name: "Auth token", status: "ok", message: "Configured", detail: nil))
+        } catch {
+            checks.append(DoctorCheck(name: "Auth token", status: "warning", message: "Not configured for URL-scheme features", detail: nil))
+        }
+
+        let overallStatus = checks.contains(where: { $0.status != "ok" }) ? "needs-attention" : "ok"
+        return DoctorReport(overallStatus: overallStatus, checks: checks)
+    }
+}
+
+private struct DoctorCheck: Codable {
+    let name: String
+    let status: String
+    let message: String
+    let detail: String?
+}

--- a/Sources/ClingsCLI/Commands/FilterCommand.swift
+++ b/Sources/ClingsCLI/Commands/FilterCommand.swift
@@ -52,7 +52,7 @@ struct FilterCommand: AsyncParsableCommand {
 
     func run() async throws {
         let filter = try FilterParser.parse(expression)
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
 
         // Fetch all open todos and filter
         var todos: [Todo] = []
@@ -66,11 +66,6 @@ struct FilterCommand: AsyncParsableCommand {
 
         // Apply filter
         let filtered = uniqueTodos.filter { filter.matches($0) }
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(formatter.format(todos: filtered))
+        print(renderTodos(filtered, list: "Filter", output: output))
     }
 }

--- a/Sources/ClingsCLI/Commands/FocusCommand.swift
+++ b/Sources/ClingsCLI/Commands/FocusCommand.swift
@@ -1,0 +1,59 @@
+// FocusCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+
+struct FocusCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "focus",
+        abstract: "Show a focused queue of high-attention tasks",
+        discussion: """
+        Build a short, opinionated working queue from open todos, prioritizing
+        overdue work and urgent items first.
+
+        EXAMPLES:
+          clings focus
+          clings focus --limit 5
+          clings focus --format "{status} {name} [{project}]"
+          clings focus --json
+        """
+    )
+
+    @Option(name: .long, help: "Maximum number of tasks to show")
+    var limit: Int = 10
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let plan = FocusPlanner().build(todos: try await fetchOpenTodos(client: client), limit: limit)
+
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(plan)
+            print(String(data: data, encoding: .utf8) ?? "{}")
+            return
+        }
+
+        if let _ = output.format {
+            print(renderTodos(plan.items.map(\.todo), list: "Focus", output: output))
+            return
+        }
+
+        if plan.items.isEmpty {
+            print("No focus items right now")
+            return
+        }
+
+        for item in plan.items {
+            let reasons = item.reasons.isEmpty ? "" : " [\(item.reasons.joined(separator: ", "))]"
+            print("- \(item.todo.name)\(reasons)")
+        }
+    }
+}

--- a/Sources/ClingsCLI/Commands/ListCommands.swift
+++ b/Sources/ClingsCLI/Commands/ListCommands.swift
@@ -14,6 +14,9 @@ struct OutputOptions: ParsableArguments {
 
     @Flag(name: .long, help: "Suppress color output")
     var noColor = false
+
+    @Option(name: .long, help: "Custom todo line template, e.g. '{status} {name} [{project}]'")
+    var format: String?
 }
 
 // MARK: - Base List Command
@@ -25,19 +28,9 @@ protocol ListCommand: AsyncParsableCommand {
 
 extension ListCommand {
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let todos = try await client.fetchList(listView)
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        // Include list name in JSON for API compatibility
-        if output.json {
-            print(formatter.format(todos: todos, list: listView.displayName))
-        } else {
-            print(formatter.format(todos: todos))
-        }
+        print(renderTodos(todos, list: listView.displayName, output: output))
     }
 }
 
@@ -232,7 +225,7 @@ struct ProjectsCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let projects = try await client.fetchProjects()
 
         let formatter: OutputFormatter = output.json
@@ -268,7 +261,7 @@ struct AreasCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let areas = try await client.fetchAreas()
 
         let formatter: OutputFormatter = output.json

--- a/Sources/ClingsCLI/Commands/MutationCommands.swift
+++ b/Sources/ClingsCLI/Commands/MutationCommands.swift
@@ -45,11 +45,7 @@ struct CompleteCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
+        let client = CommandRuntime.makeClient()
 
         // Determine which mode to use
         if let searchTitle = title {
@@ -65,7 +61,8 @@ struct CompleteCommand: AsyncParsableCommand {
                 // Exactly one match - complete it
                 let todo = openTodos[0]
                 try await client.completeTodo(id: todo.id)
-                print(formatter.format(message: "Completed: \(todo.name)"))
+                try UndoStore.record(UndoEntry(operation: .complete, todoID: todo.id, snapshot: TodoSnapshot(todo: todo)))
+                print(renderMessage("Completed: \(todo.name)", output: output))
 
             default:
                 // Multiple matches - show list with IDs
@@ -80,8 +77,10 @@ struct CompleteCommand: AsyncParsableCommand {
             }
         } else if let todoId = id {
             // Original ID-based completion
+            let snapshot = try? await client.fetchTodo(id: todoId)
             try await client.completeTodo(id: todoId)
-            print(formatter.format(message: "Completed todo: \(todoId)"))
+            try UndoStore.record(UndoEntry(operation: .complete, todoID: todoId, snapshot: snapshot.map { TodoSnapshot(todo: $0) }))
+            print(renderMessage("Completed todo: \(todoId)", output: output))
         } else {
             throw ValidationError("Provide either a todo ID or --title flag")
         }
@@ -116,14 +115,11 @@ struct CancelCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
+        let snapshot = try? await client.fetchTodo(id: id)
         try await client.cancelTodo(id: id)
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(formatter.format(message: "Canceled todo: \(id)"))
+        try UndoStore.record(UndoEntry(operation: .cancel, todoID: id, snapshot: snapshot.map { TodoSnapshot(todo: $0) }))
+        print(renderMessage("Canceled todo: \(id)", output: output))
     }
 }
 
@@ -159,14 +155,11 @@ struct DeleteCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
+        let snapshot = try? await client.fetchTodo(id: id)
         try await client.deleteTodo(id: id)
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(formatter.format(message: "Deleted todo: \(id)"))
+        try UndoStore.record(UndoEntry(operation: .delete, todoID: id, snapshot: snapshot.map { TodoSnapshot(todo: $0) }))
+        print(renderMessage("Deleted todo: \(id)", output: output))
     }
 }
 
@@ -180,7 +173,7 @@ struct UpdateCommand: AsyncParsableCommand {
         Update one or more properties of a todo by ID.
         Only specified options will be updated.
 
-        Examples:
+        EXAMPLES:
           clings update ABC123 --name "New title"
           clings update ABC123 --notes "Updated notes"
           clings update ABC123 --due 2024-12-25
@@ -223,7 +216,7 @@ struct UpdateCommand: AsyncParsableCommand {
         if let when = when {
             let validKeywords = Set(["today", "tomorrow", "evening", "anytime", "someday"])
             let isKeyword = validKeywords.contains(when.lowercased())
-            let isDate = parseDate(when) != nil
+            let isDate = parseFlexibleDate(when) != nil
             guard isKeyword || isDate else {
                 throw ThingsError.invalidState(
                     "Invalid --when value: '\(when)'. Use 'today', 'tomorrow', 'evening', 'anytime', 'someday', or YYYY-MM-DD."
@@ -265,12 +258,13 @@ struct UpdateCommand: AsyncParsableCommand {
             }
         }
 
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
+        let previousSnapshot = try? await client.fetchTodo(id: id)
 
         // Parse due date if provided
         var dueDate: Date? = nil
         if let dueStr = due {
-            dueDate = parseDate(dueStr)
+            dueDate = parseFlexibleDate(dueStr)
             if dueDate == nil {
                 throw ThingsError.invalidState("Invalid date format: \(dueStr). Use YYYY-MM-DD, 'today', or 'tomorrow'.")
             }
@@ -305,30 +299,11 @@ struct UpdateCommand: AsyncParsableCommand {
             }
         }
 
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
         let urlSchemeNote = needsURLScheme ? " (--when/--heading sent via URL scheme; verify in Things)" : ""
-        print(formatter.format(message: "Updated todo: \(id)\(urlSchemeNote)"))
-    }
-
-    private func parseDate(_ str: String) -> Date? {
-        let calendar = Calendar.current
-        let now = Date()
-        let lower = str.lowercased()
-
-        if lower == "today" {
-            return calendar.startOfDay(for: now)
+        if let previousSnapshot {
+            try UndoStore.record(UndoEntry(operation: .update, todoID: id, snapshot: TodoSnapshot(todo: previousSnapshot)))
         }
-        if lower == "tomorrow" {
-            return calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
-        }
-
-        // Try ISO date format (YYYY-MM-DD)
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.date(from: str)
+        print(renderMessage("Updated todo: \(id)\(urlSchemeNote)", output: output))
     }
 
     private func updateViaURLScheme(id: String, when: String?, heading: String?, token: String) throws {
@@ -351,17 +326,6 @@ struct UpdateCommand: AsyncParsableCommand {
             throw ThingsError.operationFailed("Failed to construct Things URL")
         }
 
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = [url]
-        do {
-            try process.run()
-        } catch {
-            throw ThingsError.operationFailed("Failed to launch Things URL scheme handler: \(error.localizedDescription)")
-        }
-        process.waitUntilExit()
-        guard process.terminationStatus == 0 else {
-            throw ThingsError.operationFailed("Failed to update via Things URL scheme (exit code \(process.terminationStatus))")
-        }
+        try CommandRuntime.openURLScheme(url)
     }
 }

--- a/Sources/ClingsCLI/Commands/PickCommand.swift
+++ b/Sources/ClingsCLI/Commands/PickCommand.swift
@@ -1,0 +1,169 @@
+// PickCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+
+struct PickCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "pick",
+        abstract: "Interactively pick a todo for a follow-up action",
+        discussion: """
+        Search visible todos, choose one interactively, and then run a follow-up
+        action without manually copying IDs.
+
+        EXAMPLES:
+          clings pick show release
+          clings pick complete docs
+          clings pick cancel follow-up
+          clings pick delete cleanup
+        """,
+        subcommands: [
+            PickShowCommand.self,
+            PickCompleteCommand.self,
+            PickCancelCommand.self,
+            PickDeleteCommand.self,
+        ]
+    )
+}
+
+struct PickShowCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "show",
+        abstract: "Pick a todo and show its details",
+        discussion: """
+        Present matching todos, let you choose one, and render the selected todo.
+
+        EXAMPLES:
+          clings pick show
+          clings pick show release
+          clings pick show docs --json
+        """
+    )
+
+    @Argument(help: "Optional search query")
+    var query: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let candidates = try await pickCandidates(client: client, query: query, includeLogbook: true, onlyOpen: false)
+        guard let todo = promptForTodoSelection(todos: candidates, prompt: "Show which todo?") else {
+            throw ValidationError("No todo selected")
+        }
+        print(renderTodo(todo, output: output))
+    }
+}
+
+struct PickCompleteCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "complete",
+        abstract: "Pick a todo and complete it",
+        discussion: """
+        Choose an open todo interactively, then mark it complete.
+
+        EXAMPLES:
+          clings pick complete
+          clings pick complete release
+        """
+    )
+
+    @Argument(help: "Optional search query")
+    var query: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let candidates = try await pickCandidates(client: client, query: query, includeLogbook: false, onlyOpen: true)
+        guard let todo = promptForTodoSelection(todos: candidates, prompt: "Complete which todo?") else {
+            throw ValidationError("No todo selected")
+        }
+        try await client.completeTodo(id: todo.id)
+        try UndoStore.record(UndoEntry(operation: .complete, todoID: todo.id, snapshot: TodoSnapshot(todo: todo)))
+        print(renderMessage("Completed: \(todo.name)", output: output))
+    }
+}
+
+struct PickCancelCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "cancel",
+        abstract: "Pick a todo and cancel it",
+        discussion: """
+        Choose an open todo interactively, then cancel it.
+
+        EXAMPLES:
+          clings pick cancel
+          clings pick cancel follow-up
+        """
+    )
+
+    @Argument(help: "Optional search query")
+    var query: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let candidates = try await pickCandidates(client: client, query: query, includeLogbook: false, onlyOpen: true)
+        guard let todo = promptForTodoSelection(todos: candidates, prompt: "Cancel which todo?") else {
+            throw ValidationError("No todo selected")
+        }
+        try await client.cancelTodo(id: todo.id)
+        try UndoStore.record(UndoEntry(operation: .cancel, todoID: todo.id, snapshot: TodoSnapshot(todo: todo)))
+        print(renderMessage("Canceled: \(todo.name)", output: output))
+    }
+}
+
+struct PickDeleteCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Pick a todo and delete it",
+        discussion: """
+        Choose an open todo interactively, then move it to the trash.
+
+        EXAMPLES:
+          clings pick delete
+          clings pick delete cleanup
+        """
+    )
+
+    @Argument(help: "Optional search query")
+    var query: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let candidates = try await pickCandidates(client: client, query: query, includeLogbook: false, onlyOpen: true)
+        guard let todo = promptForTodoSelection(todos: candidates, prompt: "Delete which todo?") else {
+            throw ValidationError("No todo selected")
+        }
+        try await client.deleteTodo(id: todo.id)
+        try UndoStore.record(UndoEntry(operation: .delete, todoID: todo.id, snapshot: TodoSnapshot(todo: todo)))
+        print(renderMessage("Deleted: \(todo.name)", output: output))
+    }
+}
+
+private func pickCandidates(
+    client: any ThingsClientProtocol,
+    query: String?,
+    includeLogbook: Bool,
+    onlyOpen: Bool
+) async throws -> [Todo] {
+    let todos: [Todo]
+    if let query, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        todos = try await client.search(query: query)
+    } else {
+        todos = try await fetchVisibleTodos(client: client, includeLogbook: includeLogbook)
+    }
+
+    let filtered = onlyOpen ? todos.filter(\.isOpen) : todos
+    guard !filtered.isEmpty else {
+        throw ValidationError("No todos available for selection")
+    }
+    return filtered
+}

--- a/Sources/ClingsCLI/Commands/ProjectCommands.swift
+++ b/Sources/ClingsCLI/Commands/ProjectCommands.swift
@@ -21,8 +21,8 @@ struct ProjectCommand: AsyncParsableCommand {
         EXAMPLES:
           clings project                    List all projects (same as 'clings projects')
           clings project list               Same as above
-          clings project add "Release Readiness"  Create a new project
-          clings project add "Documentation Refresh" --area "Operations" --deadline 2025-01-31
+          clings project add "Documentation Refresh"  Create a new project
+          clings project add "Writing Refresh" --area "Writing" --deadline 2025-01-31
 
         SEE ALSO:
           projects, add --project, areas
@@ -76,10 +76,10 @@ struct ProjectAddCommand: AsyncParsableCommand {
         Creates a new project in Things 3.
 
         EXAMPLES:
-          clings project add "Release Readiness"
-          clings project add "Feature Rollout" --notes "Implementation of rollout tasks"
-          clings project add "Operations Sprint" --area "Operations" --when today
-          clings project add "Vendor Evaluation" --deadline 2025-06-01 --tags "planning,research"
+          clings project add "Documentation Refresh"
+          clings project add "Reading List" --notes "Collect and organize reference material"
+          clings project add "Writing Sprint" --area "Writing" --when today
+          clings project add "Reference Review" --deadline 2025-06-01 --tags "planning,research"
         """
     )
 

--- a/Sources/ClingsCLI/Commands/ProjectCommands.swift
+++ b/Sources/ClingsCLI/Commands/ProjectCommands.swift
@@ -30,6 +30,7 @@ struct ProjectCommand: AsyncParsableCommand {
         subcommands: [
             ProjectListCommand.self,
             ProjectAddCommand.self,
+            ProjectAuditCommand.self,
         ],
         defaultSubcommand: ProjectListCommand.self
     )
@@ -41,13 +42,20 @@ struct ProjectListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
         abstract: "List all projects",
+        discussion: """
+        Show every project currently available in Things.
+
+        EXAMPLES:
+          clings project list
+          clings project ls --json
+        """,
         aliases: ["ls"]
     )
 
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let projects = try await client.fetchProjects()
 
         let formatter: OutputFormatter = output.json
@@ -101,7 +109,7 @@ struct ProjectAddCommand: AsyncParsableCommand {
             throw ThingsError.invalidState("Project title cannot be empty")
         }
 
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let parsedWhen = try when.map { try parseWhenDate($0) }
         let parsedDeadline = try deadline.map { try parseWhenDate($0) }
         let tagList = tags?
@@ -143,5 +151,49 @@ struct ProjectAddCommand: AsyncParsableCommand {
             return date
         }
         throw ThingsError.invalidState("Invalid date format: \(str). Use YYYY-MM-DD, 'today', or 'tomorrow'.")
+    }
+}
+
+struct ProjectAuditCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "audit",
+        abstract: "Audit project health and missing next actions",
+        discussion: """
+        Inspect open projects and flag missing next actions, overdue work, and
+        other stalled-project signals.
+
+        EXAMPLES:
+          clings project audit
+          clings project audit --json
+        """
+    )
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        let client = CommandRuntime.makeClient()
+        let report = ProjectAudit().audit(
+            projects: try await client.fetchProjects(),
+            todos: try await fetchOpenTodos(client: client)
+        )
+
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(report)
+            print(String(data: data, encoding: .utf8) ?? "{}")
+            return
+        }
+
+        if report.items.isEmpty {
+            print("No open projects to audit")
+            return
+        }
+
+        for item in report.items {
+            let findings = item.findings.isEmpty ? "Healthy" : item.findings.joined(separator: ", ")
+            print("\(item.project.name): \(findings)")
+        }
     }
 }

--- a/Sources/ClingsCLI/Commands/ReviewCommand.swift
+++ b/Sources/ClingsCLI/Commands/ReviewCommand.swift
@@ -18,6 +18,11 @@ struct ReviewCommand: AsyncParsableCommand {
         3. Check project status
         4. Review deadlines
         5. Generate summary
+
+        EXAMPLES:
+          clings review
+          clings review status
+          clings review clear
         """,
         subcommands: [
             ReviewStartCommand.self,
@@ -33,7 +38,15 @@ struct ReviewCommand: AsyncParsableCommand {
 struct ReviewStartCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "start",
-        abstract: "Start or resume a weekly review"
+        abstract: "Start or resume a weekly review",
+        discussion: """
+        Walk through inbox, someday, projects, deadlines, and a short weekly
+        summary, then persist the review session locally.
+
+        EXAMPLES:
+          clings review
+          clings review start
+        """
     )
 
     @OptionGroup var output: OutputOptions
@@ -52,11 +65,22 @@ struct ReviewStartCommand: AsyncParsableCommand {
         print("\(bold)📋 Weekly Review\(reset)")
         print("\(dim)─────────────────────────────────────\(reset)")
 
-        let db = try ThingsDatabase()
+        let db = try CommandRuntime.makeDatabase()
+        let inbox = try db.fetchList(.inbox)
+        let someday = try db.fetchList(.someday)
+        let projects = try db.fetchProjects()
+        let upcoming = try db.fetchList(.upcoming)
+        let today = try db.fetchList(.today)
+        let summary = ReviewAssistant().summarize(
+            inbox: inbox,
+            someday: someday,
+            today: today,
+            upcoming: upcoming,
+            projects: projects
+        )
 
         // Step 1: Inbox
         print("\n\(bold)Step 1: Process Inbox\(reset)")
-        let inbox = try db.fetchList(.inbox)
         if inbox.isEmpty {
             print("  \(green)✓ Inbox is empty!\(reset)")
         } else {
@@ -66,7 +90,6 @@ struct ReviewStartCommand: AsyncParsableCommand {
 
         // Step 2: Someday/Maybe
         print("\n\(bold)Step 2: Review Someday/Maybe\(reset)")
-        let someday = try db.fetchList(.someday)
         print("  \(someday.count) items in Someday")
         if !someday.isEmpty {
             print("  \(dim)Consider: Which items should be activated?\(reset)")
@@ -74,58 +97,42 @@ struct ReviewStartCommand: AsyncParsableCommand {
 
         // Step 3: Projects
         print("\n\(bold)Step 3: Check Projects\(reset)")
-        let projects = try db.fetchProjects()
         let activeProjects = projects.filter { $0.status == .open }
         print("  \(activeProjects.count) active projects")
-
-        // Find stalled projects (no recent activity)
-        let weekAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())!
-        var stalledCount = 0
-        for project in activeProjects {
-            // A project is "stalled" if it has no todos in today/upcoming
-            // This is a simplified heuristic
-            if let created = project.creationDate, created < weekAgo {
-                stalledCount += 1
-            }
-        }
-        if stalledCount > 0 {
-            print("  \(yellow)⚠ \(stalledCount) projects may need attention\(reset)")
+        if !summary.stalledProjects.isEmpty {
+            print("  \(yellow)⚠ \(summary.stalledProjects.count) projects may need attention\(reset)")
         }
 
         // Step 4: Deadlines
         print("\n\(bold)Step 4: Review Deadlines\(reset)")
-        let upcoming = try db.fetchList(.upcoming)
-        let today = try db.fetchList(.today)
-        let allOpen = upcoming + today
-
-        let nextWeek = Calendar.current.date(byAdding: .day, value: 7, to: Date())!
-        let upcomingDeadlines = allOpen.filter { todo in
-            guard let due = todo.dueDate else { return false }
-            return due <= nextWeek
-        }
-
-        if upcomingDeadlines.isEmpty {
+        if summary.upcomingDeadlines.isEmpty {
             print("  \(green)✓ No deadlines in the next 7 days\(reset)")
         } else {
-            print("  \(cyan)\(upcomingDeadlines.count) deadlines in the next 7 days:\(reset)")
-            for todo in upcomingDeadlines.prefix(5) {
+            print("  \(cyan)\(summary.upcomingDeadlines.count) deadlines in the next 7 days:\(reset)")
+            for todo in summary.upcomingDeadlines.prefix(5) {
                 let dueStr = todo.dueDate.map { formatDate($0) } ?? ""
                 print("    • \(todo.name) \(dim)(\(dueStr))\(reset)")
             }
-            if upcomingDeadlines.count > 5 {
-                print("    \(dim)... and \(upcomingDeadlines.count - 5) more\(reset)")
+            if summary.upcomingDeadlines.count > 5 {
+                print("    \(dim)... and \(summary.upcomingDeadlines.count - 5) more\(reset)")
             }
         }
 
         // Step 5: Summary
         print("\n\(bold)Step 5: Summary\(reset)")
-        let todayCount = try db.fetchList(.today).count
+        let todayCount = today.count
         let stats = try StatsCollector().collect(days: 7)
 
         print("  Today's todos:        \(todayCount)")
         print("  Completed this week:  \(green)\(stats.completedInPeriod)\(reset)")
         print("  Inbox items:          \(inbox.count)")
         print("  Overdue items:        \(stats.overdue > 0 ? "\(yellow)\(stats.overdue)\(reset)" : "0")")
+        if !summary.suggestedActions.isEmpty {
+            print("\n\(bold)Suggested Actions\(reset)")
+            for action in summary.suggestedActions {
+                print("  • \(action)")
+            }
+        }
 
         // Save session
         var updatedSession = session
@@ -149,7 +156,14 @@ struct ReviewStartCommand: AsyncParsableCommand {
 struct ReviewStatusCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "status",
-        abstract: "Show current review session status"
+        abstract: "Show current review session status",
+        discussion: """
+        Show the last saved review timestamp and whether the core review steps
+        have been marked complete.
+
+        EXAMPLES:
+          clings review status
+        """
     )
 
     @OptionGroup var output: OutputOptions
@@ -184,7 +198,13 @@ struct ReviewStatusCommand: AsyncParsableCommand {
 struct ReviewClearCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "clear",
-        abstract: "Clear the current review session"
+        abstract: "Clear the current review session",
+        discussion: """
+        Delete the saved weekly review session so the next run starts fresh.
+
+        EXAMPLES:
+          clings review clear
+        """
     )
 
     func run() async throws {
@@ -207,25 +227,22 @@ struct ReviewSession: Codable {
     }
 
     private static var sessionPath: URL {
-        let configDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".clings")
-        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
-        return configDir.appendingPathComponent("review-session.json")
+        (try? ClingsConfig.fileURL(named: "review-session.json"))
+            ?? FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".clings/review-session.json")
     }
 
     static func load() -> ReviewSession? {
-        guard let data = try? Data(contentsOf: sessionPath) else { return nil }
-        return try? JSONDecoder().decode(ReviewSession.self, from: data)
+        if !FileManager.default.fileExists(atPath: sessionPath.path) {
+            return nil
+        }
+        return try? JSONFileStore.load(ReviewSession.self, from: "review-session.json", default: ReviewSession())
     }
 
     func save() {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(self) else { return }
-        try? data.write(to: Self.sessionPath)
+        try? JSONFileStore.save(self, to: "review-session.json")
     }
 
     static func clear() {
-        try? FileManager.default.removeItem(at: sessionPath)
+        try? JSONFileStore.delete(fileName: "review-session.json")
     }
 }

--- a/Sources/ClingsCLI/Commands/SearchCommand.swift
+++ b/Sources/ClingsCLI/Commands/SearchCommand.swift
@@ -35,13 +35,8 @@ struct SearchCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let todos = try await client.search(query: query)
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(formatter.format(todos: todos))
+        print(renderTodos(todos, list: "Search", output: output))
     }
 }

--- a/Sources/ClingsCLI/Commands/ShowCommand.swift
+++ b/Sources/ClingsCLI/Commands/ShowCommand.swift
@@ -37,13 +37,8 @@ struct ShowCommand: AsyncParsableCommand {
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let todo = try await client.fetchTodo(id: id)
-
-        let formatter: OutputFormatter = output.json
-            ? JSONOutputFormatter()
-            : TextOutputFormatter(useColors: !output.noColor)
-
-        print(formatter.format(todo: todo))
+        print(renderTodo(todo, output: output))
     }
 }

--- a/Sources/ClingsCLI/Commands/StatsCommand.swift
+++ b/Sources/ClingsCLI/Commands/StatsCommand.swift
@@ -18,6 +18,13 @@ struct StatsCommand: AsyncParsableCommand {
         - Overdue items
         - Tag distribution
 
+        EXAMPLES:
+          clings stats
+          clings stats --days 7
+          clings stats --json
+          clings stats trends
+          clings stats heatmap
+
         Use 'stats trends' for completion trends over time.
         Use 'stats heatmap' for a GitHub-style contribution calendar.
         """,
@@ -203,7 +210,7 @@ struct Stats: Codable {
 
 struct StatsCollector {
     func collect(days: Int) throws -> Stats {
-        let db = try ThingsDatabase()
+        let db = try CommandRuntime.makeDatabase()
 
         // Fetch all lists
         let inbox = try db.fetchList(.inbox)
@@ -285,7 +292,7 @@ struct StatsCollector {
 
     /// Collect daily completion counts for trends/heatmap.
     func collectDailyCompletions(days: Int) throws -> [Date: Int] {
-        let db = try ThingsDatabase()
+        let db = try CommandRuntime.makeDatabase()
         let logbook = try db.fetchList(.logbook)
 
         let calendar = Calendar.current

--- a/Sources/ClingsCLI/Commands/TagCommands.swift
+++ b/Sources/ClingsCLI/Commands/TagCommands.swift
@@ -47,13 +47,20 @@ struct TagsListCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "list",
         abstract: "List all tags",
+        discussion: """
+        Show every tag currently available in Things.
+
+        EXAMPLES:
+          clings tags list
+          clings tags ls --json
+        """,
         aliases: ["ls"]
     )
 
     @OptionGroup var output: OutputOptions
 
     func run() async throws {
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let tags = try await client.fetchTags()
 
         let formatter: OutputFormatter = output.json
@@ -92,7 +99,7 @@ struct TagsAddCommand: AsyncParsableCommand {
             throw ThingsError.invalidState("Tag name cannot be empty")
         }
 
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         let tag = try await client.createTag(name: trimmedName)
 
         let formatter: OutputFormatter = output.json
@@ -143,14 +150,14 @@ struct TagsDeleteCommand: AsyncParsableCommand {
         // Confirmation unless --force
         if !force {
             print("Delete tag '\(trimmedName)'? This will remove it from all todos. [y/N] ", terminator: "")
-            guard let response = readLine()?.lowercased(),
+            guard let response = CommandRuntime.inputReader()?.lowercased(),
                   response == "y" || response == "yes" else {
                 print("Cancelled")
                 return
             }
         }
 
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         try await client.deleteTag(name: trimmedName)
 
         let formatter: OutputFormatter = output.json
@@ -201,7 +208,7 @@ struct TagsRenameCommand: AsyncParsableCommand {
             throw ThingsError.invalidState("Old and new names are the same")
         }
 
-        let client = ThingsClientFactory.create()
+        let client = CommandRuntime.makeClient()
         try await client.renameTag(oldName: trimmedOld, newName: trimmedNew)
 
         let formatter: OutputFormatter = output.json

--- a/Sources/ClingsCLI/Commands/TemplateCommand.swift
+++ b/Sources/ClingsCLI/Commands/TemplateCommand.swift
@@ -1,0 +1,192 @@
+// TemplateCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+
+struct TemplateCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "template",
+        abstract: "Manage reusable task templates",
+        discussion: """
+        Save reusable task blueprints with notes, tags, checklist items, and relative
+        schedule expressions.
+
+        EXAMPLES:
+          clings template save weekly-review "Weekly review" --when "tomorrow morning"
+          clings template list
+          clings template run weekly-review
+          clings template delete weekly-review
+        """,
+        subcommands: [
+            TemplateListCommand.self,
+            TemplateSaveCommand.self,
+            TemplateRunCommand.self,
+            TemplateDeleteCommand.self,
+        ],
+        defaultSubcommand: TemplateListCommand.self
+    )
+}
+
+struct TemplateListCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List saved templates",
+        discussion: """
+        Show all saved templates and the task title each template creates.
+
+        EXAMPLES:
+          clings template list
+          clings template ls --json
+        """,
+        aliases: ["ls"]
+    )
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+        let templates = try TemplateStore.list()
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(templates)
+            print(String(data: data, encoding: .utf8) ?? "[]")
+            return
+        }
+
+        if templates.isEmpty {
+            print("No saved templates")
+            return
+        }
+
+        for template in templates {
+            print("\(template.name): \(template.title)")
+        }
+    }
+}
+
+struct TemplateSaveCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "save",
+        abstract: "Save a task template",
+        discussion: """
+        Capture a reusable task skeleton for repeatable work.
+
+        EXAMPLES:
+          clings template save weekly-review "Weekly review" --when "tomorrow morning"
+          clings template save release-checklist "Prepare release notes #docs" --checklist "Draft" "Review"
+        """
+    )
+
+    @Argument(help: "Template name")
+    var name: String
+
+    @Argument(help: "Template title or natural-language task")
+    var title: String
+
+    @Option(name: .long, help: "Notes to store with the template")
+    var notes: String?
+
+    @Option(name: .long, help: "Store a relative when expression, e.g. 'tomorrow morning'")
+    var when: String?
+
+    @Option(name: .long, help: "Store a relative deadline expression, e.g. 'next friday'")
+    var deadline: String?
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Store tags")
+    var tags: [String] = []
+
+    @Option(name: .long, help: "Default project")
+    var project: String?
+
+    @Option(name: .long, help: "Default area")
+    var area: String?
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Checklist items")
+    var checklist: [String] = []
+
+    func run() throws {
+        let parsed = TaskParser().parse(title)
+        let template = TaskTemplate(
+            name: name,
+            title: parsed.title,
+            notes: notes ?? parsed.notes,
+            tags: tags.isEmpty ? parsed.tags : tags,
+            project: project ?? parsed.project,
+            area: area ?? parsed.area,
+            whenExpression: when,
+            deadlineExpression: deadline,
+            checklistItems: checklist.isEmpty ? parsed.checklistItems : checklist
+        )
+        try TemplateStore.save(template)
+        print("Saved template: \(name)")
+    }
+}
+
+struct TemplateRunCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Create a task from a template",
+        discussion: """
+        Instantiate a saved template as a new todo in Things.
+
+        EXAMPLES:
+          clings template run weekly-review
+          clings template run release-checklist --json
+        """
+    )
+
+    @Argument(help: "Template name")
+    var name: String
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        guard let template = try TemplateStore.load(name: name) else {
+            throw ValidationError("Template not found: \(name)")
+        }
+
+        let client = CommandRuntime.makeClient()
+        let id = try await client.createTodo(
+            name: template.title,
+            notes: template.notes,
+            when: parseFlexibleDate(template.whenExpression),
+            deadline: parseFlexibleDate(template.deadlineExpression),
+            tags: template.tags,
+            project: template.project,
+            area: template.area,
+            checklistItems: template.checklistItems
+        )
+        try UndoStore.record(UndoEntry(operation: .create, todoID: id, snapshot: nil))
+        print(renderMessage("Created from template: \(template.title)", output: output))
+    }
+}
+
+struct TemplateDeleteCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete a template",
+        discussion: """
+        Remove a saved template from local clings state.
+
+        EXAMPLES:
+          clings template delete weekly-review
+          clings template rm release-checklist
+        """,
+        aliases: ["rm"]
+    )
+
+    @Argument(help: "Template name")
+    var name: String
+
+    func run() throws {
+        guard try TemplateStore.delete(name: name) else {
+            throw ValidationError("Template not found: \(name)")
+        }
+        print("Deleted template: \(name)")
+    }
+}

--- a/Sources/ClingsCLI/Commands/UndoCommand.swift
+++ b/Sources/ClingsCLI/Commands/UndoCommand.swift
@@ -1,0 +1,83 @@
+// UndoCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+
+struct UndoCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "undo",
+        abstract: "Undo the most recent supported mutation",
+        discussion: """
+        Reverses the most recent supported write operation recorded by clings.
+
+        EXAMPLES:
+          clings undo
+          clings undo --show
+
+        Supported operations:
+          create     Deletes the newly created todo
+          update     Restores the previous snapshot
+          complete   Reopens the todo
+          cancel     Reopens the todo
+          delete     Reopens the todo
+        """
+    )
+
+    @Flag(name: .long, help: "Show the most recent undo entry without applying it")
+    var show = false
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        if show {
+            guard let entry = try UndoStore.latest() else {
+                print(renderMessage("No undo history available", output: output))
+                return
+            }
+            print(renderUndoEntry(entry))
+            return
+        }
+
+        guard let entry = try UndoStore.popLatest() else {
+            print(renderMessage("Nothing to undo", output: output))
+            return
+        }
+
+        let client = CommandRuntime.makeClient()
+        switch entry.operation {
+        case .create:
+            try await client.deleteTodo(id: entry.todoID)
+        case .update:
+            guard let snapshot = entry.snapshot else {
+                throw ValidationError("Undo entry is missing update snapshot data")
+            }
+            try await client.updateTodo(
+                id: entry.todoID,
+                name: snapshot.name,
+                notes: snapshot.notes,
+                dueDate: snapshot.dueDate,
+                tags: snapshot.tags
+            )
+        case .complete, .cancel, .delete:
+            try await client.reopenTodo(id: entry.todoID)
+        }
+
+        print(renderMessage("Undid \(entry.operation.rawValue) for \(entry.todoID)", output: output))
+    }
+
+    private func renderUndoEntry(_ entry: UndoEntry) -> String {
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try? encoder.encode(entry)
+            return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+        }
+
+        return "Latest undo: \(entry.operation.rawValue) \(entry.todoID)"
+    }
+}

--- a/Sources/ClingsCLI/Commands/ViewsCommand.swift
+++ b/Sources/ClingsCLI/Commands/ViewsCommand.swift
@@ -81,7 +81,7 @@ struct ViewsSaveCommand: ParsableCommand {
         Store a reusable filter expression under a short name.
 
         EXAMPLES:
-          clings views save work-today "area = 'Work' AND due <= today"
+          clings views save docs-today "tags CONTAINS 'docs' AND due <= today"
           clings views save docs "tags CONTAINS 'docs'" --note "Documentation queue"
         """
     )
@@ -110,7 +110,7 @@ struct ViewsRunCommand: AsyncParsableCommand {
         matching open todos.
 
         EXAMPLES:
-          clings views run work-today
+          clings views run docs-today
           clings views run docs --json
           clings views run docs --format "{status} {name} [{project}]"
         """
@@ -141,7 +141,7 @@ struct ViewsDeleteCommand: ParsableCommand {
         Remove a saved view you no longer need.
 
         EXAMPLES:
-          clings views delete work-today
+          clings views delete docs-today
           clings views rm docs
         """,
         aliases: ["rm"]

--- a/Sources/ClingsCLI/Commands/ViewsCommand.swift
+++ b/Sources/ClingsCLI/Commands/ViewsCommand.swift
@@ -1,0 +1,159 @@
+// ViewsCommand.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+
+struct ViewsCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "views",
+        abstract: "Manage saved filter views",
+        discussion: """
+        Save named filter expressions so you can reuse them without retyping DSL.
+
+        EXAMPLES:
+          clings views save docs "tags CONTAINS 'docs'" --note "Documentation queue"
+          clings views list
+          clings views run docs --json
+          clings views delete docs
+        """,
+        subcommands: [
+            ViewsListCommand.self,
+            ViewsSaveCommand.self,
+            ViewsRunCommand.self,
+            ViewsDeleteCommand.self,
+        ],
+        defaultSubcommand: ViewsListCommand.self
+    )
+}
+
+struct ViewsListCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List saved views",
+        discussion: """
+        Show every saved view name, the filter expression it runs, and any note you
+        stored alongside it.
+
+        EXAMPLES:
+          clings views list
+          clings views ls --json
+        """,
+        aliases: ["ls"]
+    )
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+        let views = try SavedViewStore.list()
+        if output.json {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            encoder.dateEncodingStrategy = .iso8601
+            let data = try encoder.encode(views)
+            print(String(data: data, encoding: .utf8) ?? "[]")
+            return
+        }
+
+        if views.isEmpty {
+            print("No saved views")
+            return
+        }
+
+        for view in views {
+            if let note = view.note, !note.isEmpty {
+                print("\(view.name): \(view.expression)  # \(note)")
+            } else {
+                print("\(view.name): \(view.expression)")
+            }
+        }
+    }
+}
+
+struct ViewsSaveCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "save",
+        abstract: "Save a named filter view",
+        discussion: """
+        Store a reusable filter expression under a short name.
+
+        EXAMPLES:
+          clings views save work-today "area = 'Work' AND due <= today"
+          clings views save docs "tags CONTAINS 'docs'" --note "Documentation queue"
+        """
+    )
+
+    @Argument(help: "View name")
+    var name: String
+
+    @Argument(help: "Filter expression")
+    var expression: String
+
+    @Option(name: .long, help: "Optional description for this view")
+    var note: String?
+
+    func run() throws {
+        try SavedViewStore.save(SavedView(name: name, expression: expression, note: note))
+        print("Saved view: \(name)")
+    }
+}
+
+struct ViewsRunCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "run",
+        abstract: "Run a saved filter view",
+        discussion: """
+        Load a saved view by name, evaluate its filter expression, and render the
+        matching open todos.
+
+        EXAMPLES:
+          clings views run work-today
+          clings views run docs --json
+          clings views run docs --format "{status} {name} [{project}]"
+        """
+    )
+
+    @Argument(help: "View name")
+    var name: String
+
+    @OptionGroup var output: OutputOptions
+
+    func run() async throws {
+        guard let view = try SavedViewStore.load(name: name) else {
+            throw ValidationError("Saved view not found: \(name)")
+        }
+
+        let filter = try FilterParser.parse(view.expression)
+        let client = CommandRuntime.makeClient()
+        let todos = try await fetchOpenTodos(client: client).filter { filter.matches($0) }
+        print(renderTodos(todos, list: view.name, output: output))
+    }
+}
+
+struct ViewsDeleteCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "delete",
+        abstract: "Delete a saved view",
+        discussion: """
+        Remove a saved view you no longer need.
+
+        EXAMPLES:
+          clings views delete work-today
+          clings views rm docs
+        """,
+        aliases: ["rm"]
+    )
+
+    @Argument(help: "View name")
+    var name: String
+
+    func run() throws {
+        guard try SavedViewStore.delete(name: name) else {
+            throw ValidationError("Saved view not found: \(name)")
+        }
+        print("Deleted view: \(name)")
+    }
+}

--- a/Sources/ClingsCLI/Support/CommandRuntime.swift
+++ b/Sources/ClingsCLI/Support/CommandRuntime.swift
@@ -1,0 +1,36 @@
+// CommandRuntime.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ClingsCore
+import Foundation
+
+enum CommandRuntime {
+    @TaskLocal static var makeClient: @Sendable () -> any ThingsClientProtocol = {
+        ThingsClientFactory.create()
+    }
+
+    @TaskLocal static var makeDatabase: @Sendable () throws -> any ThingsDatabaseReadable = {
+        try ThingsDatabase()
+    }
+
+    @TaskLocal static var inputReader: @Sendable () -> String? = {
+        Swift.readLine()
+    }
+
+    @TaskLocal static var openURLScheme: @Sendable (String) throws -> Void = { urlString in
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        process.arguments = [urlString]
+        do {
+            try process.run()
+        } catch {
+            throw ThingsError.operationFailed("Failed to launch Things URL scheme handler: \(error.localizedDescription)")
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            throw ThingsError.operationFailed("Failed to update via Things URL scheme (exit code \(process.terminationStatus))")
+        }
+    }
+}

--- a/Sources/ClingsCLI/Support/CommandSupport.swift
+++ b/Sources/ClingsCLI/Support/CommandSupport.swift
@@ -1,0 +1,109 @@
+// CommandSupport.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ClingsCore
+import Foundation
+
+func makeFormatter(output: OutputOptions) -> OutputFormatter {
+    output.json
+        ? JSONOutputFormatter()
+        : TextOutputFormatter(useColors: !output.noColor)
+}
+
+func renderTodos(_ todos: [Todo], list: String? = nil, output: OutputOptions) -> String {
+    if output.json {
+        let formatter = JSONOutputFormatter()
+        return list.map { formatter.format(todos: todos, list: $0) } ?? formatter.format(todos: todos)
+    }
+
+    if let template = output.format {
+        guard !todos.isEmpty else {
+            return TextOutputFormatter(useColors: !output.noColor).format(todos: [])
+        }
+        let formatter = TodoLineFormatter(template: template)
+        return todos.map { formatter.format(todo: $0) }.joined(separator: "\n")
+    }
+
+    let formatter = TextOutputFormatter(useColors: !output.noColor)
+    return list.map { formatter.format(todos: todos, list: $0) } ?? formatter.format(todos: todos)
+}
+
+func renderTodo(_ todo: Todo, output: OutputOptions) -> String {
+    if output.json {
+        return JSONOutputFormatter().format(todo: todo)
+    }
+    if let template = output.format {
+        return TodoLineFormatter(template: template).format(todo: todo)
+    }
+    return TextOutputFormatter(useColors: !output.noColor).format(todo: todo)
+}
+
+func renderMessage(_ message: String, output: OutputOptions) -> String {
+    makeFormatter(output: output).format(message: message)
+}
+
+func fetchOpenTodos(client: any ThingsClientProtocol) async throws -> [Todo] {
+    let lists: [ListView] = [.today, .inbox, .upcoming, .anytime, .someday]
+    var todos: [Todo] = []
+    for list in lists {
+        todos.append(contentsOf: try await client.fetchList(list))
+    }
+    return uniqueTodos(todos)
+}
+
+func fetchVisibleTodos(client: any ThingsClientProtocol, includeLogbook: Bool = false) async throws -> [Todo] {
+    var todos = try await fetchOpenTodos(client: client)
+    if includeLogbook {
+        todos.append(contentsOf: try await client.fetchList(.logbook))
+    }
+    return uniqueTodos(todos)
+}
+
+func uniqueTodos(_ todos: [Todo]) -> [Todo] {
+    var seen: Set<String> = []
+    var unique: [Todo] = []
+    for todo in todos where !seen.contains(todo.id) {
+        seen.insert(todo.id)
+        unique.append(todo)
+    }
+    return unique
+}
+
+func parseFlexibleDate(_ expression: String?) -> Date? {
+    guard let expression else { return nil }
+    return NaturalLanguageDateParser().parse(expression)
+}
+
+func promptForTodoSelection(
+    todos: [Todo],
+    prompt: String,
+    inputReader: () -> String? = { CommandRuntime.inputReader() }
+) -> Todo? {
+    guard !todos.isEmpty else {
+        return nil
+    }
+
+    print(prompt)
+    for (index, todo) in todos.enumerated() {
+        let due = todo.dueDate.map {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter.string(from: $0)
+        } ?? "no due date"
+        print("  \(index + 1). \(todo.name) [\(todo.id)] (\(due))")
+    }
+    print("Enter a number or todo ID:", terminator: " ")
+
+    guard let rawSelection = inputReader()?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !rawSelection.isEmpty else {
+        return nil
+    }
+
+    if let index = Int(rawSelection), todos.indices.contains(index - 1) {
+        return todos[index - 1]
+    }
+
+    return todos.first { $0.id == rawSelection }
+}

--- a/Sources/ClingsCore/Analysis/FocusPlanner.swift
+++ b/Sources/ClingsCore/Analysis/FocusPlanner.swift
@@ -1,0 +1,80 @@
+// FocusPlanner.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public struct FocusItem: Codable, Equatable, Sendable {
+    public let todo: Todo
+    public let score: Int
+    public let reasons: [String]
+}
+
+public struct FocusPlan: Codable, Equatable, Sendable {
+    public let items: [FocusItem]
+}
+
+public struct FocusPlanner: Sendable {
+    public init() {}
+
+    public func build(todos: [Todo], limit: Int = 10, referenceDate: Date = Date()) -> FocusPlan {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: referenceDate)
+        let endOfTomorrow = calendar.date(byAdding: .day, value: 2, to: startOfToday) ?? startOfToday
+
+        let items = todos
+            .filter(\.isOpen)
+            .map { todo in
+                var score = 0
+                var reasons: [String] = []
+
+                if todo.isOverdue {
+                    score += 100
+                    reasons.append("Overdue")
+                }
+
+                if let dueDate = todo.dueDate {
+                    if calendar.isDate(dueDate, inSameDayAs: referenceDate) {
+                        score += 60
+                        reasons.append("Due today")
+                    } else if dueDate < endOfTomorrow {
+                        score += 35
+                        reasons.append("Due soon")
+                    }
+                }
+
+                if todo.tags.contains(where: { ["urgent", "priority", "high"].contains($0.name.lowercased()) }) {
+                    score += 25
+                    reasons.append("Urgent tag")
+                }
+
+                if todo.project == nil {
+                    score += 5
+                    reasons.append("Unassigned")
+                }
+
+                return FocusItem(todo: todo, score: score, reasons: reasons)
+            }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score {
+                    return lhs.score > rhs.score
+                }
+                switch (lhs.todo.dueDate, rhs.todo.dueDate) {
+                case let (left?, right?):
+                    if left != right {
+                        return left < right
+                    }
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                case (nil, nil):
+                    break
+                }
+                return lhs.todo.name.localizedCaseInsensitiveCompare(rhs.todo.name) == .orderedAscending
+            }
+
+        return FocusPlan(items: Array(items.prefix(limit)))
+    }
+}

--- a/Sources/ClingsCore/Analysis/ProjectAudit.swift
+++ b/Sources/ClingsCore/Analysis/ProjectAudit.swift
@@ -1,0 +1,83 @@
+// ProjectAudit.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public struct ProjectAuditSummary: Codable, Equatable, Sendable {
+    public let totalProjects: Int
+    public let projectsWithoutNextActions: Int
+    public let projectsWithOverdueTasks: Int
+    public let projectsWithoutDeadlines: Int
+}
+
+public struct ProjectAuditItem: Codable, Equatable, Sendable {
+    public let project: Project
+    public let openTodoCount: Int
+    public let overdueCount: Int
+    public let nextActionCount: Int
+    public let findings: [String]
+    public let latestActivityDate: Date?
+}
+
+public struct ProjectAuditReport: Codable, Equatable, Sendable {
+    public let items: [ProjectAuditItem]
+    public let summary: ProjectAuditSummary
+}
+
+public struct ProjectAudit: Sendable {
+    public init() {}
+
+    public func audit(projects: [Project], todos: [Todo], referenceDate: Date = Date()) -> ProjectAuditReport {
+        let calendar = Calendar.current
+        let staleThreshold = calendar.date(byAdding: .day, value: -14, to: referenceDate) ?? referenceDate
+
+        let items = projects
+            .filter { $0.status == .open }
+            .map { project in
+                let projectTodos = todos.filter { $0.status == .open && $0.project?.id == project.id }
+                let overdue = projectTodos.filter(\.isOverdue)
+                let latestActivity = projectTodos.map(\.modificationDate).max()
+
+                var findings: [String] = []
+                if projectTodos.isEmpty {
+                    findings.append("No next actions")
+                }
+                if !overdue.isEmpty {
+                    findings.append("Overdue tasks")
+                }
+                if project.dueDate == nil {
+                    findings.append("No deadline")
+                }
+                if let latestActivity, latestActivity < staleThreshold {
+                    findings.append("Stale activity")
+                }
+
+                return ProjectAuditItem(
+                    project: project,
+                    openTodoCount: projectTodos.count,
+                    overdueCount: overdue.count,
+                    nextActionCount: projectTodos.count,
+                    findings: findings,
+                    latestActivityDate: latestActivity
+                )
+            }
+            .sorted {
+                if $0.findings.count != $1.findings.count {
+                    return $0.findings.count > $1.findings.count
+                }
+                return $0.project.name.localizedCaseInsensitiveCompare($1.project.name) == .orderedAscending
+            }
+
+        return ProjectAuditReport(
+            items: items,
+            summary: ProjectAuditSummary(
+                totalProjects: items.count,
+                projectsWithoutNextActions: items.filter { $0.findings.contains("No next actions") }.count,
+                projectsWithOverdueTasks: items.filter { $0.findings.contains("Overdue tasks") }.count,
+                projectsWithoutDeadlines: items.filter { $0.findings.contains("No deadline") }.count
+            )
+        )
+    }
+}

--- a/Sources/ClingsCore/Analysis/ReviewAssistant.swift
+++ b/Sources/ClingsCore/Analysis/ReviewAssistant.swift
@@ -1,0 +1,73 @@
+// ReviewAssistant.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public struct ReviewSummary: Equatable, Sendable {
+    public let inboxCount: Int
+    public let somedayCount: Int
+    public let activeProjectCount: Int
+    public let stalledProjects: [Project]
+    public let upcomingDeadlines: [Todo]
+    public let overdueTodos: [Todo]
+    public let suggestedActions: [String]
+}
+
+public struct ReviewAssistant: Sendable {
+    public init() {}
+
+    public func summarize(
+        inbox: [Todo],
+        someday: [Todo],
+        today: [Todo],
+        upcoming: [Todo],
+        projects: [Project],
+        referenceDate: Date = Date()
+    ) -> ReviewSummary {
+        let calendar = Calendar.current
+        let nextWeek = calendar.date(byAdding: .day, value: 7, to: referenceDate) ?? referenceDate
+        let activeProjects = projects.filter { $0.status == .open }
+        let openTimeline = (today + upcoming).filter(\.isOpen)
+
+        let overdueTodos = openTimeline.filter(\.isOverdue)
+        let upcomingDeadlines = openTimeline
+            .filter {
+                guard let dueDate = $0.dueDate else { return false }
+                return dueDate <= nextWeek
+            }
+            .sorted { ($0.dueDate ?? nextWeek) < ($1.dueDate ?? nextWeek) }
+
+        let stalledProjects = activeProjects.filter { project in
+            !openTimeline.contains { $0.project?.id == project.id }
+        }
+
+        var suggestedActions: [String] = []
+        if !inbox.isEmpty {
+            suggestedActions.append("Inbox needs processing")
+        }
+        if !overdueTodos.isEmpty {
+            suggestedActions.append("Overdue tasks need replanning")
+        }
+        if !stalledProjects.isEmpty {
+            suggestedActions.append("Some projects have no visible next actions")
+        }
+        if !someday.isEmpty {
+            suggestedActions.append("Review Someday for items worth activating")
+        }
+        if suggestedActions.isEmpty {
+            suggestedActions.append("System looks healthy; keep the review lightweight")
+        }
+
+        return ReviewSummary(
+            inboxCount: inbox.count,
+            somedayCount: someday.count,
+            activeProjectCount: activeProjects.count,
+            stalledProjects: stalledProjects,
+            upcomingDeadlines: upcomingDeadlines,
+            overdueTodos: overdueTodos,
+            suggestedActions: suggestedActions
+        )
+    }
+}

--- a/Sources/ClingsCore/Config/AuthTokenStore.swift
+++ b/Sources/ClingsCore/Config/AuthTokenStore.swift
@@ -8,9 +8,7 @@ import Foundation
 /// Manages the Things 3 auth token used for URL scheme operations (e.g., heading updates).
 public enum AuthTokenStore {
     private static var configDir: URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".config")
-            .appendingPathComponent("clings")
+        ClingsConfig.directoryURL
     }
 
     private static var tokenFile: URL {

--- a/Sources/ClingsCore/Config/ClingsConfig.swift
+++ b/Sources/ClingsCore/Config/ClingsConfig.swift
@@ -1,0 +1,35 @@
+// ClingsConfig.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Shared configuration paths and helpers for local clings state.
+public enum ClingsConfig {
+    private static let envKey = "CLINGS_CONFIG_DIR"
+
+    public static var directoryURL: URL {
+        if let rawValue = getenv(envKey) {
+            let override = String(cString: rawValue).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !override.isEmpty {
+                return URL(fileURLWithPath: override, isDirectory: true)
+            }
+        }
+
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config")
+            .appendingPathComponent("clings")
+    }
+
+    @discardableResult
+    public static func ensureDirectory() throws -> URL {
+        let url = directoryURL
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    public static func fileURL(named fileName: String) throws -> URL {
+        try ensureDirectory().appendingPathComponent(fileName)
+    }
+}

--- a/Sources/ClingsCore/Config/JSONFileStore.swift
+++ b/Sources/ClingsCore/Config/JSONFileStore.swift
@@ -1,0 +1,46 @@
+// JSONFileStore.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Lightweight JSON persistence for user-local clings state.
+public enum JSONFileStore {
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    public static func load<T: Decodable>(_ type: T.Type, from fileName: String, default defaultValue: @autoclosure () -> T) throws -> T {
+        let url = try ClingsConfig.fileURL(named: fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return defaultValue()
+        }
+
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(type, from: data)
+    }
+
+    public static func save<T: Encodable>(_ value: T, to fileName: String) throws {
+        let url = try ClingsConfig.fileURL(named: fileName)
+        let data = try encoder.encode(value)
+        try data.write(to: url, options: .atomic)
+    }
+
+    public static func delete(fileName: String) throws {
+        let url = try ClingsConfig.fileURL(named: fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        try FileManager.default.removeItem(at: url)
+    }
+}

--- a/Sources/ClingsCore/Config/SavedViewStore.swift
+++ b/Sources/ClingsCore/Config/SavedViewStore.swift
@@ -1,0 +1,60 @@
+// SavedViewStore.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public struct SavedView: Codable, Equatable, Sendable {
+    public let name: String
+    public let expression: String
+    public let note: String?
+    public let createdAt: Date
+
+    public init(name: String, expression: String, note: String? = nil, createdAt: Date = Date()) {
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.expression = expression.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.note = note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.createdAt = createdAt
+    }
+}
+
+public enum SavedViewStore {
+    private static let fileName = "saved-views.json"
+
+    public static func list() throws -> [SavedView] {
+        try JSONFileStore
+            .load([SavedView].self, from: fileName, default: [])
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    public static func load(name: String) throws -> SavedView? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try list().first { $0.name == trimmed }
+    }
+
+    public static func save(_ view: SavedView) throws {
+        guard !view.name.isEmpty else {
+            throw ThingsError.invalidState("Saved view name cannot be empty")
+        }
+        guard !view.expression.isEmpty else {
+            throw ThingsError.invalidState("Saved view expression cannot be empty")
+        }
+
+        var views = try list().filter { $0.name != view.name }
+        views.append(view)
+        try JSONFileStore.save(views, to: fileName)
+    }
+
+    @discardableResult
+    public static func delete(name: String) throws -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let existing = try list()
+        let remaining = existing.filter { $0.name != trimmed }
+        guard remaining.count != existing.count else {
+            return false
+        }
+        try JSONFileStore.save(remaining, to: fileName)
+        return true
+    }
+}

--- a/Sources/ClingsCore/Config/TemplateStore.swift
+++ b/Sources/ClingsCore/Config/TemplateStore.swift
@@ -1,0 +1,83 @@
+// TemplateStore.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public struct TaskTemplate: Codable, Equatable, Sendable {
+    public let name: String
+    public let title: String
+    public let notes: String?
+    public let tags: [String]
+    public let project: String?
+    public let area: String?
+    public let whenExpression: String?
+    public let deadlineExpression: String?
+    public let checklistItems: [String]
+    public let createdAt: Date
+
+    public init(
+        name: String,
+        title: String,
+        notes: String? = nil,
+        tags: [String] = [],
+        project: String? = nil,
+        area: String? = nil,
+        whenExpression: String? = nil,
+        deadlineExpression: String? = nil,
+        checklistItems: [String] = [],
+        createdAt: Date = Date()
+    ) {
+        self.name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.notes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.tags = tags
+        self.project = project?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.area = area?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.whenExpression = whenExpression?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.deadlineExpression = deadlineExpression?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.checklistItems = checklistItems
+        self.createdAt = createdAt
+    }
+}
+
+public enum TemplateStore {
+    private static let fileName = "templates.json"
+
+    public static func list() throws -> [TaskTemplate] {
+        try JSONFileStore
+            .load([TaskTemplate].self, from: fileName, default: [])
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    public static func load(name: String) throws -> TaskTemplate? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try list().first { $0.name == trimmed }
+    }
+
+    public static func save(_ template: TaskTemplate) throws {
+        guard !template.name.isEmpty else {
+            throw ThingsError.invalidState("Template name cannot be empty")
+        }
+        guard !template.title.isEmpty else {
+            throw ThingsError.invalidState("Template title cannot be empty")
+        }
+
+        var templates = try list().filter { $0.name != template.name }
+        templates.append(template)
+        try JSONFileStore.save(templates, to: fileName)
+    }
+
+    @discardableResult
+    public static func delete(name: String) throws -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let existing = try list()
+        let remaining = existing.filter { $0.name != trimmed }
+        guard remaining.count != existing.count else {
+            return false
+        }
+        try JSONFileStore.save(remaining, to: fileName)
+        return true
+    }
+}

--- a/Sources/ClingsCore/Config/UndoStore.swift
+++ b/Sources/ClingsCore/Config/UndoStore.swift
@@ -1,0 +1,110 @@
+// UndoStore.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+public enum UndoOperation: String, Codable, Equatable, Sendable {
+    case create
+    case update
+    case complete
+    case cancel
+    case delete
+}
+
+public struct TodoSnapshot: Codable, Equatable, Sendable {
+    public let id: String
+    public let name: String
+    public let notes: String?
+    public let dueDate: Date?
+    public let tags: [String]
+    public let status: Status
+    public let projectName: String?
+    public let areaName: String?
+
+    public init(
+        id: String,
+        name: String,
+        notes: String? = nil,
+        dueDate: Date? = nil,
+        tags: [String] = [],
+        status: Status,
+        projectName: String? = nil,
+        areaName: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.notes = notes
+        self.dueDate = dueDate
+        self.tags = tags
+        self.status = status
+        self.projectName = projectName
+        self.areaName = areaName
+    }
+
+    public init(todo: Todo) {
+        self.init(
+            id: todo.id,
+            name: todo.name,
+            notes: todo.notes,
+            dueDate: todo.dueDate,
+            tags: todo.tags.map(\.name),
+            status: todo.status,
+            projectName: todo.project?.name,
+            areaName: todo.area?.name
+        )
+    }
+}
+
+public struct UndoEntry: Codable, Equatable, Sendable {
+    public let operation: UndoOperation
+    public let todoID: String
+    public let snapshot: TodoSnapshot?
+    public let createdAt: Date
+
+    public init(operation: UndoOperation, todoID: String, snapshot: TodoSnapshot?, createdAt: Date = Date()) {
+        self.operation = operation
+        self.todoID = todoID
+        self.snapshot = snapshot
+        self.createdAt = createdAt
+    }
+}
+
+public enum UndoStore {
+    private static let fileName = "undo-history.json"
+    private static let maxEntries = 20
+
+    public static func list() throws -> [UndoEntry] {
+        try JSONFileStore
+            .load([UndoEntry].self, from: fileName, default: [])
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    public static func latest() throws -> UndoEntry? {
+        try list().first
+    }
+
+    public static func record(_ entry: UndoEntry) throws {
+        var entries = try list().filter { !($0.todoID == entry.todoID && $0.createdAt == entry.createdAt) }
+        entries.insert(entry, at: 0)
+        if entries.count > maxEntries {
+            entries = Array(entries.prefix(maxEntries))
+        }
+        try JSONFileStore.save(entries, to: fileName)
+    }
+
+    public static func popLatest() throws -> UndoEntry? {
+        var entries = try list()
+        guard !entries.isEmpty else {
+            return nil
+        }
+        let latest = entries.removeFirst()
+        try JSONFileStore.save(entries, to: fileName)
+        return latest
+    }
+
+    public static func clear() throws {
+        try JSONFileStore.save([UndoEntry](), to: fileName)
+    }
+}

--- a/Sources/ClingsCore/NLP/NaturalLanguageDateParser.swift
+++ b/Sources/ClingsCore/NLP/NaturalLanguageDateParser.swift
@@ -1,0 +1,196 @@
+// NaturalLanguageDateParser.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Parses lightweight natural-language scheduling phrases into dates.
+public struct NaturalLanguageDateParser: Sendable {
+    public init() {}
+
+    public func parse(_ input: String, referenceDate: Date = Date()) -> Date? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lower = trimmed.lowercased()
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: referenceDate)
+
+        let extractedTime = extractTime(from: lower)
+        var datePhrase = extractedTime.remaining
+
+        let implicitHour: Int?
+        if datePhrase == "this evening" || datePhrase == "evening" || datePhrase == "tonight" {
+            implicitHour = 18
+            datePhrase = "today"
+        } else if datePhrase == "tomorrow morning" {
+            implicitHour = 9
+            datePhrase = "tomorrow"
+        } else if datePhrase == "tomorrow evening" || datePhrase == "tomorrow night" {
+            implicitHour = 18
+            datePhrase = "tomorrow"
+        } else if datePhrase == "morning" {
+            implicitHour = 9
+            datePhrase = "today"
+        } else {
+            implicitHour = nil
+        }
+
+        let baseDate: Date?
+        if datePhrase == "today" {
+            baseDate = startOfDay
+        } else if datePhrase == "tomorrow" {
+            baseDate = calendar.date(byAdding: .day, value: 1, to: startOfDay)
+        } else if datePhrase == "next week" {
+            baseDate = calendar.date(byAdding: .day, value: 7, to: startOfDay)
+        } else if let inDays = parseRelativeDays(datePhrase, calendar: calendar, startOfDay: startOfDay) {
+            baseDate = inDays
+        } else if let weekday = weekdayFromName(datePhrase.replacingOccurrences(of: "next ", with: "")) {
+            baseDate = nextOccurrence(of: weekday, from: referenceDate, forceNextWeek: datePhrase.hasPrefix("next "))
+        } else if let absolute = parseAbsoluteDate(datePhrase, referenceDate: referenceDate) {
+            baseDate = absolute
+        } else {
+            baseDate = nil
+        }
+
+        guard let baseDate else { return nil }
+        let hour = extractedTime.hour ?? implicitHour
+        let minute = extractedTime.minute ?? 0
+        guard let hour else { return calendar.startOfDay(for: baseDate) }
+
+        return calendar.date(
+            bySettingHour: hour,
+            minute: minute,
+            second: 0,
+            of: calendar.startOfDay(for: baseDate)
+        )
+    }
+
+    private func parseRelativeDays(_ input: String, calendar: Calendar, startOfDay: Date) -> Date? {
+        let pattern = #"^in\s+(\d+)\s+days?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+              let match = regex.firstMatch(in: input, range: NSRange(input.startIndex..., in: input)),
+              let range = Range(match.range(at: 1), in: input),
+              let days = Int(input[range]) else {
+            return nil
+        }
+        return calendar.date(byAdding: .day, value: days, to: startOfDay)
+    }
+
+    private func parseAbsoluteDate(_ input: String, referenceDate: Date) -> Date? {
+        let calendar = Calendar.current
+        let lower = input.lowercased()
+
+        let isoFormatter = DateFormatter()
+        isoFormatter.locale = Locale(identifier: "en_US_POSIX")
+        isoFormatter.timeZone = TimeZone.current
+        isoFormatter.dateFormat = "yyyy-MM-dd"
+        if let date = isoFormatter.date(from: lower) {
+            return calendar.startOfDay(for: date)
+        }
+
+        for format in ["MMM d yyyy", "MMMM d yyyy", "MMM d", "MMMM d"] {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone.current
+            formatter.dateFormat = format
+
+            if format.contains("yyyy"), let date = formatter.date(from: lower) {
+                return calendar.startOfDay(for: date)
+            }
+
+            if let date = formatter.date(from: lower) {
+                let components = calendar.dateComponents([.month, .day], from: date)
+                var merged = calendar.dateComponents([.year], from: referenceDate)
+                merged.month = components.month
+                merged.day = components.day
+                if let candidate = calendar.date(from: merged) {
+                    let candidateStart = calendar.startOfDay(for: candidate)
+                    if candidateStart < calendar.startOfDay(for: referenceDate),
+                       let nextYear = calendar.date(byAdding: .year, value: 1, to: candidateStart) {
+                        return nextYear
+                    }
+                    return candidateStart
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func weekdayFromName(_ name: String) -> Int? {
+        let mapping: [String: Int] = [
+            "sunday": 1, "sun": 1,
+            "monday": 2, "mon": 2,
+            "tuesday": 3, "tue": 3,
+            "wednesday": 4, "wed": 4,
+            "thursday": 5, "thu": 5,
+            "friday": 6, "fri": 6,
+            "saturday": 7, "sat": 7,
+        ]
+        return mapping[name]
+    }
+
+    private func nextOccurrence(of weekday: Int, from date: Date, forceNextWeek: Bool) -> Date? {
+        let calendar = Calendar.current
+        let todayWeekday = calendar.component(.weekday, from: date)
+        var daysToAdd = weekday - todayWeekday
+        if daysToAdd < 0 || (daysToAdd == 0 && forceNextWeek) {
+            daysToAdd += 7
+        }
+        if forceNextWeek, daysToAdd == 0 {
+            daysToAdd = 7
+        }
+        return calendar.date(byAdding: .day, value: daysToAdd == 0 ? 7 : daysToAdd, to: calendar.startOfDay(for: date))
+    }
+
+    private func extractTime(from input: String) -> (remaining: String, hour: Int?, minute: Int?) {
+        let patterns = [
+            #"(?:\s|^)(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b"#,
+            #"(?:\s|^)(\d{1,2}):(\d{2})\b"#,
+        ]
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+                  let match = regex.firstMatch(in: input, range: NSRange(input.startIndex..., in: input)),
+                  let fullRange = Range(match.range, in: input),
+                  let hourRange = Range(match.range(at: 1), in: input) else {
+                continue
+            }
+
+            let rawHour = Int(input[hourRange]) ?? 0
+            let rawMinute: Int
+            if let minuteRange = Range(match.range(at: 2), in: input) {
+                rawMinute = Int(input[minuteRange]) ?? 0
+            } else {
+                rawMinute = 0
+            }
+
+            let meridiem: String?
+            if match.numberOfRanges > 3, let meridiemRange = Range(match.range(at: 3), in: input) {
+                meridiem = String(input[meridiemRange]).lowercased()
+            } else {
+                meridiem = nil
+            }
+
+            var hour = rawHour
+            if let meridiem {
+                if meridiem == "pm", hour < 12 {
+                    hour += 12
+                }
+                if meridiem == "am", hour == 12 {
+                    hour = 0
+                }
+            }
+
+            let remaining = input.replacingCharacters(in: fullRange, with: " ")
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            return (remaining, hour, rawMinute)
+        }
+
+        return (input.trimmingCharacters(in: .whitespacesAndNewlines), nil, nil)
+    }
+}

--- a/Sources/ClingsCore/NLP/TaskParser.swift
+++ b/Sources/ClingsCore/NLP/TaskParser.swift
@@ -42,6 +42,8 @@ public struct ParsedTask: Sendable {
 
 /// Parses natural language task descriptions into structured data.
 public struct TaskParser: Sendable {
+    private let dateParser = NaturalLanguageDateParser()
+
     public init() {}
 
     /// Parse a natural language task string.
@@ -111,9 +113,9 @@ public struct TaskParser: Sendable {
             }
         }
 
-        // Extract project (for ProjectName)
-        let projectPattern = #"\bfor\s+([A-Z][^\s#!]+(?:\s+[A-Z][^\s#!]+)*)"#
-        if let regex = try? NSRegularExpression(pattern: projectPattern, options: []),
+        // Extract quoted project (for "Project Name")
+        let quotedProjectPattern = #"\bfor\s+"([^"]+)""#
+        if let regex = try? NSRegularExpression(pattern: quotedProjectPattern, options: []),
            let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
            let projectRange = Range(match.range(at: 1), in: remaining),
            let fullRange = Range(match.range, in: remaining) {
@@ -121,9 +123,20 @@ public struct TaskParser: Sendable {
             remaining.removeSubrange(fullRange)
         }
 
-        // Extract area (in AreaName) - but not "in X days"
-        let areaPattern = #"\bin\s+([A-Z][^\s#!]+(?:\s+[A-Z][^\s#!]+)*)(?!\s+days?)"#
-        if let regex = try? NSRegularExpression(pattern: areaPattern, options: []),
+        // Extract project (for ProjectName)
+        let projectPattern = #"\bfor\s+([A-Z][^\s#!]+(?:\s+[A-Z][^\s#!]+)*)"#
+        if project == nil,
+           let regex = try? NSRegularExpression(pattern: projectPattern, options: []),
+           let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
+           let projectRange = Range(match.range(at: 1), in: remaining),
+           let fullRange = Range(match.range, in: remaining) {
+            project = String(remaining[projectRange]).trimmingCharacters(in: .whitespaces)
+            remaining.removeSubrange(fullRange)
+        }
+
+        // Extract quoted area (in "Area Name")
+        let quotedAreaPattern = #"\bin\s+"([^"]+)""#
+        if let regex = try? NSRegularExpression(pattern: quotedAreaPattern, options: []),
            let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
            let areaRange = Range(match.range(at: 1), in: remaining),
            let fullRange = Range(match.range, in: remaining) {
@@ -131,30 +144,46 @@ public struct TaskParser: Sendable {
             remaining.removeSubrange(fullRange)
         }
 
-        // Extract deadline (by friday, by dec 15)
-        let deadlinePattern = #"\bby\s+(\w+(?:\s+\d+)?)"#
+        // Extract area (in AreaName) - but not "in X days"
+        let areaPattern = #"\bin\s+([A-Z][^\s#!]+(?:\s+[A-Z][^\s#!]+)*)(?!\s+days?)"#
+        if area == nil,
+           let regex = try? NSRegularExpression(pattern: areaPattern, options: []),
+           let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
+           let areaRange = Range(match.range(at: 1), in: remaining),
+           let fullRange = Range(match.range, in: remaining) {
+            area = String(remaining[areaRange]).trimmingCharacters(in: .whitespaces)
+            remaining.removeSubrange(fullRange)
+        }
+
+        // Extract deadline (by friday, by dec 15, by dec 15 3pm)
+        let deadlinePattern = #"\bby\s+((?:next\s+\w+|today|tomorrow|this evening|tomorrow morning|tomorrow evening|in\s+\d+\s+days?|(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2}(?:\s+\d{1,2}(?::\d{2})?\s*(?:am|pm))?|\w+(?:\s+\d{1,2}(?::\d{2})?\s*(?:am|pm))?))"#
         if let regex = try? NSRegularExpression(pattern: deadlinePattern, options: .caseInsensitive),
            let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
            let dateRange = Range(match.range(at: 1), in: remaining),
            let fullRange = Range(match.range, in: remaining) {
             let dateStr = String(remaining[dateRange])
-            dueDate = parseDate(dateStr)
+            dueDate = dateParser.parse(dateStr)
             remaining.removeSubrange(fullRange)
         }
 
-        // Extract when date (tomorrow, next monday, dec 15)
+        // Extract when date (tomorrow, next monday, dec 15, dec 15 3pm)
         let whenPatterns = [
+            #"\btomorrow\s+(?:morning|evening|\d{1,2}(?::\d{2})?\s*(?:am|pm))\b"#,
+            #"\btoday\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)\b"#,
+            #"\bthis evening\b"#,
             #"\btomorrow\b"#,
             #"\btoday\b"#,
-            #"\bnext\s+\w+"#,
-            #"\bin\s+\d+\s+days?"#,
+            #"\bnext\s+\w+\b"#,
+            #"\bin\s+\d+\s+days?\b"#,
+            #"\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2}(?:\s+\d{1,2}(?::\d{2})?\s*(?:am|pm))?\b"#,
+            #"\b(?:monday|mon|tuesday|tue|wednesday|wed|thursday|thu|friday|fri|saturday|sat|sunday|sun)(?:\s+\d{1,2}(?::\d{2})?\s*(?:am|pm))?\b"#,
         ]
         for pattern in whenPatterns {
             if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
                let match = regex.firstMatch(in: remaining, options: [], range: NSRange(remaining.startIndex..., in: remaining)),
                let range = Range(match.range, in: remaining) {
                 let dateStr = String(remaining[range])
-                whenDate = parseDate(dateStr)
+                whenDate = dateParser.parse(dateStr)
                 remaining.removeSubrange(range)
                 break
             }
@@ -181,63 +210,6 @@ public struct TaskParser: Sendable {
 
     /// Parse a date string into a Date.
     private func parseDate(_ str: String) -> Date? {
-        let calendar = Calendar.current
-        let now = Date()
-
-        let lower = str.lowercased()
-
-        // Relative dates
-        if lower == "today" {
-            return calendar.startOfDay(for: now)
-        }
-        if lower == "tomorrow" {
-            return calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
-        }
-
-        // "in X days"
-        if lower.hasPrefix("in ") {
-            let parts = lower.split(separator: " ")
-            if parts.count >= 2, let days = Int(parts[1]) {
-                return calendar.date(byAdding: .day, value: days, to: calendar.startOfDay(for: now))
-            }
-        }
-
-        // "next monday", "next friday", etc.
-        if lower.hasPrefix("next ") {
-            let dayName = String(lower.dropFirst(5))
-            if let weekday = weekdayFromName(dayName) {
-                return nextOccurrence(of: weekday, from: now)
-            }
-        }
-
-        // Day names (monday, tuesday, etc.)
-        if let weekday = weekdayFromName(lower) {
-            return nextOccurrence(of: weekday, from: now)
-        }
-
-        return nil
-    }
-
-    private func weekdayFromName(_ name: String) -> Int? {
-        let mapping: [String: Int] = [
-            "sunday": 1, "sun": 1,
-            "monday": 2, "mon": 2,
-            "tuesday": 3, "tue": 3,
-            "wednesday": 4, "wed": 4,
-            "thursday": 5, "thu": 5,
-            "friday": 6, "fri": 6,
-            "saturday": 7, "sat": 7,
-        ]
-        return mapping[name.lowercased()]
-    }
-
-    private func nextOccurrence(of weekday: Int, from date: Date) -> Date? {
-        let calendar = Calendar.current
-        let todayWeekday = calendar.component(.weekday, from: date)
-        var daysToAdd = weekday - todayWeekday
-        if daysToAdd <= 0 {
-            daysToAdd += 7
-        }
-        return calendar.date(byAdding: .day, value: daysToAdd, to: calendar.startOfDay(for: date))
+        dateParser.parse(str)
     }
 }

--- a/Sources/ClingsCore/Output/TodoLineFormatter.swift
+++ b/Sources/ClingsCore/Output/TodoLineFormatter.swift
@@ -1,0 +1,36 @@
+// TodoLineFormatter.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+
+/// Formats a todo using placeholder substitution.
+public struct TodoLineFormatter: Sendable {
+    public let template: String
+
+    public init(template: String) {
+        self.template = template
+    }
+
+    public func format(todo: Todo) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        let replacements: [String: String] = [
+            "id": todo.id,
+            "name": todo.name,
+            "status": todo.status.rawValue,
+            "due": todo.dueDate.map { formatter.string(from: $0) } ?? "",
+            "project": todo.project?.name ?? "",
+            "area": todo.area?.name ?? "",
+            "tags": todo.tags.map { "#\($0.name)" }.joined(separator: " "),
+        ]
+
+        var output = template
+        for (key, value) in replacements {
+            output = output.replacingOccurrences(of: "{\(key)}", with: value)
+        }
+        return output
+    }
+}

--- a/Sources/ClingsCore/ThingsClient/HybridThingsClient.swift
+++ b/Sources/ClingsCore/ThingsClient/HybridThingsClient.swift
@@ -7,12 +7,17 @@ import Foundation
 
 /// Hybrid Things client that uses SQLite for fast reads and JXA/AppleScript for writes.
 public final class HybridThingsClient: ThingsClientProtocol, @unchecked Sendable {
-    private let database: ThingsDatabase
-    private let jxaBridge: JXABridge
+    private let database: any ThingsDatabaseReadable
+    private let jxaBridge: any JXAExecuting
 
     public init() throws {
         self.database = try ThingsDatabase()
         self.jxaBridge = JXABridge()
+    }
+
+    init(database: any ThingsDatabaseReadable, jxaBridge: any JXAExecuting) {
+        self.database = database
+        self.jxaBridge = jxaBridge
     }
 
     // MARK: - Reads (via SQLite - fast)
@@ -122,6 +127,14 @@ public final class HybridThingsClient: ThingsClientProtocol, @unchecked Sendable
 
     public func completeTodo(id: String) async throws {
         let script = JXAScripts.completeTodo(id: id)
+        let result = try await jxaBridge.executeJSON(script, as: MutationResult.self)
+        if !result.success {
+            throw ThingsError.operationFailed(result.error ?? "Unknown error")
+        }
+    }
+
+    public func reopenTodo(id: String) async throws {
+        let script = JXAScripts.reopenTodo(id: id)
         let result = try await jxaBridge.executeJSON(script, as: MutationResult.self)
         if !result.success {
             throw ThingsError.operationFailed(result.error ?? "Unknown error")

--- a/Sources/ClingsCore/ThingsClient/JXABridge.swift
+++ b/Sources/ClingsCore/ThingsClient/JXABridge.swift
@@ -36,6 +36,13 @@ public enum JXAError: Error, LocalizedError {
 ///
 /// This actor provides safe, concurrent access to osascript execution with
 /// timeout handling and proper error reporting.
+public protocol JXAExecuting: Sendable {
+    func execute(_ script: String) async throws -> String
+    func executeJSON<T: Decodable & Sendable>(_ script: String, as type: T.Type) async throws -> T
+    func executeAppleScript(_ script: String) async throws -> String
+    func isThingsRunning() async -> Bool
+}
+
 public actor JXABridge {
     /// Default timeout for script execution in seconds.
     public static let defaultTimeout: TimeInterval = 30.0
@@ -110,7 +117,7 @@ public actor JXABridge {
     ///   - type: The type to decode the JSON into.
     /// - Returns: The decoded value.
     /// - Throws: `JXAError` if execution or decoding fails.
-    public func executeJSON<T: Decodable>(_ script: String, as type: T.Type) async throws -> T {
+    public func executeJSON<T: Decodable & Sendable>(_ script: String, as type: T.Type) async throws -> T {
         let output = try await execute(script)
 
         guard !output.isEmpty else {
@@ -238,3 +245,5 @@ public actor JXABridge {
         }
     }
 }
+
+extension JXABridge: JXAExecuting {}

--- a/Sources/ClingsCore/ThingsClient/JXAScripts.swift
+++ b/Sources/ClingsCore/ThingsClient/JXAScripts.swift
@@ -210,6 +210,23 @@ public enum JXAScripts {
         """
     }
 
+    /// Re-open a todo by ID.
+    public static func reopenTodo(id: String) -> String {
+        """
+        (() => {
+            const app = Application('Things3');
+            const todo = app.toDos.byId('\(id.jxaEscaped)');
+
+            if (!todo.exists()) {
+                return JSON.stringify({ success: false, error: 'Todo not found' });
+            }
+
+            todo.status = 'open';
+            return JSON.stringify({ success: true, id: '\(id.jxaEscaped)' });
+        })()
+        """
+    }
+
     /// Cancel a todo by ID.
     public static func cancelTodo(id: String) -> String {
         """

--- a/Sources/ClingsCore/ThingsClient/ThingsClient.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsClient.swift
@@ -59,6 +59,7 @@ public protocol ThingsClientProtocol: Sendable {
         area: String?
     ) async throws -> String
     func completeTodo(id: String) async throws
+    func reopenTodo(id: String) async throws
     func cancelTodo(id: String) async throws
     func deleteTodo(id: String) async throws
     func moveTodo(id: String, toProject: String) async throws
@@ -77,15 +78,24 @@ public protocol ThingsClientProtocol: Sendable {
     func openInThings(list: ListView) throws
 }
 
+public protocol ThingsDatabaseReadable: Sendable {
+    func fetchList(_ list: ListView) throws -> [Todo]
+    func fetchProjects() throws -> [Project]
+    func fetchAreas() throws -> [Area]
+    func fetchTags() throws -> [Tag]
+    func fetchTodo(id: String) throws -> Todo
+    func search(query: String) throws -> [Todo]
+}
+
 /// Result from a mutation operation.
-struct MutationResult: Decodable {
+struct MutationResult: Decodable, Sendable {
     let success: Bool
     let error: String?
     let id: String?
 }
 
 /// Result from a creation operation.
-struct CreationResult: Decodable {
+struct CreationResult: Decodable, Sendable {
     let success: Bool
     let error: String?
     let id: String?
@@ -93,18 +103,18 @@ struct CreationResult: Decodable {
 }
 
 /// Error response from JXA.
-struct ErrorResponse: Decodable {
+struct ErrorResponse: Decodable, Sendable {
     let error: String
     let id: String?
 }
 
 /// Client for interacting with Things 3 via JXA.
 public actor ThingsClient: ThingsClientProtocol {
-    private let bridge: JXABridge
+    private let bridge: any JXAExecuting
 
     /// Create a new Things client.
     /// - Parameter bridge: The JXA bridge to use for script execution.
-    public init(bridge: JXABridge = JXABridge()) {
+    public init(bridge: any JXAExecuting = JXABridge()) {
         self.bridge = bridge
     }
 
@@ -252,6 +262,14 @@ public actor ThingsClient: ThingsClientProtocol {
 
     public func completeTodo(id: String) async throws {
         let script = JXAScripts.completeTodo(id: id)
+        let result = try await bridge.executeJSON(script, as: MutationResult.self)
+        if !result.success {
+            throw ThingsError.operationFailed(result.error ?? "Unknown error")
+        }
+    }
+
+    public func reopenTodo(id: String) async throws {
+        let script = JXAScripts.reopenTodo(id: id)
         let result = try await bridge.executeJSON(script, as: MutationResult.self)
         if !result.success {
             throw ThingsError.operationFailed(result.error ?? "Unknown error")

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -401,3 +401,5 @@ public final class ThingsDatabase: Sendable {
         return (year << 16) | (month << 12) | (day << 7)
     }
 }
+
+extension ThingsDatabase: ThingsDatabaseReadable {}

--- a/Tests/ClingsCLITests/ArgumentParsingTests.swift
+++ b/Tests/ClingsCLITests/ArgumentParsingTests.swift
@@ -15,6 +15,7 @@ struct ArgumentParsingTests {
             let options = try OutputOptions.parse([])
             #expect(!options.json)
             #expect(!options.noColor)
+            #expect(options.format == nil)
         }
 
         @Test func jsonFlag() throws {
@@ -31,6 +32,11 @@ struct ArgumentParsingTests {
             let options = try OutputOptions.parse(["--json", "--no-color"])
             #expect(options.json)
             #expect(options.noColor)
+        }
+
+        @Test func formatOption() throws {
+            let options = try OutputOptions.parse(["--format", "{name}"])
+            #expect(options.format == "{name}")
         }
     }
 
@@ -240,6 +246,11 @@ struct ArgumentParsingTests {
             let command = try AddCommand.parse(["Task", "--parse-only"])
             #expect(command.parseOnly)
         }
+
+        @Test func templateOption() throws {
+            let command = try AddCommand.parse(["Task", "--template", "daily"])
+            #expect(command.template == "daily")
+        }
     }
 
     @Suite("Search Command")
@@ -397,6 +408,47 @@ struct ArgumentParsingTests {
             let config = ReviewCommand.configuration
             #expect(!config.subcommands.isEmpty)
             #expect(config.defaultSubcommand != nil)
+        }
+    }
+
+    @Suite("New Command Parsing")
+    struct NewCommandParsing {
+        @Test func doctorVerboseFlag() throws {
+            let command = try DoctorCommand.parse(["--verbose"])
+            #expect(command.verbose)
+        }
+
+        @Test func viewsSaveCommand() throws {
+            let command = try ViewsSaveCommand.parse(["work", "status = open", "--note", "Daily"])
+            #expect(command.name == "work")
+            #expect(command.expression == "status = open")
+            #expect(command.note == "Daily")
+        }
+
+        @Test func templateRunCommand() throws {
+            let command = try TemplateRunCommand.parse(["weekly-review"])
+            #expect(command.name == "weekly-review")
+        }
+
+        @Test func undoShowFlag() throws {
+            let command = try UndoCommand.parse(["--show"])
+            #expect(command.show)
+        }
+
+        @Test func focusLimitAndFormat() throws {
+            let command = try FocusCommand.parse(["--limit", "5", "--format", "{name}"])
+            #expect(command.limit == 5)
+            #expect(command.output.format == "{name}")
+        }
+
+        @Test func pickCompleteQuery() throws {
+            let command = try PickCompleteCommand.parse(["release"])
+            #expect(command.query == "release")
+        }
+
+        @Test func projectAuditJson() throws {
+            let command = try ProjectAuditCommand.parse(["--json"])
+            #expect(command.output.json)
         }
     }
 

--- a/Tests/ClingsCLITests/CommandConfigurationTests.swift
+++ b/Tests/ClingsCLITests/CommandConfigurationTests.swift
@@ -19,12 +19,22 @@ struct CommandConfigurationTests {
 
         @Test func hasVersion() {
             let config = Clings.configuration
-            #expect(config.version != nil)
+            #expect(!config.version.isEmpty)
         }
 
         @Test func subcommands() {
             let config = Clings.configuration
             #expect(!config.subcommands.isEmpty)
+        }
+
+        @Test func includesNewTopLevelCommands() {
+            let subcommandNames = Set(Clings.configuration.subcommands.map { $0.configuration.commandName })
+            #expect(subcommandNames.contains("doctor"))
+            #expect(subcommandNames.contains("views"))
+            #expect(subcommandNames.contains("template"))
+            #expect(subcommandNames.contains("undo"))
+            #expect(subcommandNames.contains("focus"))
+            #expect(subcommandNames.contains("pick"))
         }
     }
 
@@ -117,8 +127,52 @@ struct CommandConfigurationTests {
 
         @Test func discussionContainsExamples() {
             let config = AddCommand.configuration
+            #expect(config.discussion.contains("EXAMPLES:"))
             #expect(config.discussion.contains("clings add"))
             #expect(config.discussion.contains("#"))
+        }
+    }
+
+    @Suite("Help Text")
+    struct HelpText {
+        @Test func keyCommandsIncludeExamplesInDiscussion() {
+            let discussions: [(String, String)] = [
+                ("clings", Clings.configuration.discussion),
+                ("add", AddCommand.configuration.discussion),
+                ("stats", StatsCommand.configuration.discussion),
+                ("doctor", DoctorCommand.configuration.discussion),
+                ("focus", FocusCommand.configuration.discussion),
+                ("undo", UndoCommand.configuration.discussion),
+                ("views", ViewsCommand.configuration.discussion),
+                ("views list", ViewsListCommand.configuration.discussion),
+                ("views save", ViewsSaveCommand.configuration.discussion),
+                ("views run", ViewsRunCommand.configuration.discussion),
+                ("views delete", ViewsDeleteCommand.configuration.discussion),
+                ("template", TemplateCommand.configuration.discussion),
+                ("template list", TemplateListCommand.configuration.discussion),
+                ("template save", TemplateSaveCommand.configuration.discussion),
+                ("template run", TemplateRunCommand.configuration.discussion),
+                ("template delete", TemplateDeleteCommand.configuration.discussion),
+                ("pick", PickCommand.configuration.discussion),
+                ("pick show", PickShowCommand.configuration.discussion),
+                ("pick complete", PickCompleteCommand.configuration.discussion),
+                ("pick cancel", PickCancelCommand.configuration.discussion),
+                ("pick delete", PickDeleteCommand.configuration.discussion),
+                ("review", ReviewCommand.configuration.discussion),
+                ("review start", ReviewStartCommand.configuration.discussion),
+                ("review status", ReviewStatusCommand.configuration.discussion),
+                ("review clear", ReviewClearCommand.configuration.discussion),
+                ("project list", ProjectListCommand.configuration.discussion),
+                ("project audit", ProjectAuditCommand.configuration.discussion),
+                ("tags list", TagsListCommand.configuration.discussion),
+                ("completions", CompletionsCommand.configuration.discussion),
+                ("config set-auth-token", SetAuthToken.configuration.discussion),
+            ]
+
+            for (name, discussion) in discussions {
+                #expect(!discussion.isEmpty, "\(name) should include detailed help text")
+                #expect(discussion.contains("EXAMPLES:"), "\(name) should include examples")
+            }
         }
     }
 
@@ -196,6 +250,47 @@ struct CommandConfigurationTests {
         @Test func configuration() {
             let config = ReviewCommand.configuration
             #expect(config.commandName == "review")
+        }
+    }
+
+    @Suite("New Commands")
+    struct NewCommands {
+        @Test func doctorCommand() {
+            let config = DoctorCommand.configuration
+            #expect(config.commandName == "doctor")
+        }
+
+        @Test func viewsCommand() {
+            let config = ViewsCommand.configuration
+            #expect(config.commandName == "views")
+            #expect(!config.subcommands.isEmpty)
+        }
+
+        @Test func templateCommand() {
+            let config = TemplateCommand.configuration
+            #expect(config.commandName == "template")
+            #expect(!config.subcommands.isEmpty)
+        }
+
+        @Test func undoCommand() {
+            let config = UndoCommand.configuration
+            #expect(config.commandName == "undo")
+        }
+
+        @Test func focusCommand() {
+            let config = FocusCommand.configuration
+            #expect(config.commandName == "focus")
+        }
+
+        @Test func pickCommand() {
+            let config = PickCommand.configuration
+            #expect(config.commandName == "pick")
+            #expect(!config.subcommands.isEmpty)
+        }
+
+        @Test func projectAuditCommand() {
+            let config = ProjectAuditCommand.configuration
+            #expect(config.commandName == "audit")
         }
     }
 

--- a/Tests/ClingsCLITests/CommandExecutionTests.swift
+++ b/Tests/ClingsCLITests/CommandExecutionTests.swift
@@ -1,0 +1,586 @@
+// CommandExecutionTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ArgumentParser
+import ClingsCore
+import Foundation
+import Testing
+@testable import ClingsCLI
+
+@Suite("Command Execution", .serialized)
+struct CommandExecutionTests {
+    @Test func commandSupportHelpersRenderDeduplicateAndSelect() async throws {
+        let todo = CommandFixtures.todo(
+            id: "todo-1",
+            name: "Draft release notes",
+            tags: [CommandFixtures.docsTag, CommandFixtures.urgentTag]
+        )
+        let other = CommandFixtures.todo(id: "todo-2", name: "Plan review", project: nil, area: nil)
+        let client = RecordingThingsClient()
+        client.todosForList = [
+            .today: [todo],
+            .inbox: [todo, other],
+            .upcoming: [],
+            .anytime: [],
+            .someday: [],
+            .logbook: [CommandFixtures.todo(id: "done-1", name: "Finished", status: .completed)],
+        ]
+
+        let formattedOutput = try OutputOptions.parse(["--format", "{name} [{project}]"])
+        let rendered = renderTodos([todo], list: "Today", output: formattedOutput)
+        #expect(rendered == "Draft release notes [Release]")
+
+        let openTodos = try await fetchOpenTodos(client: client)
+        #expect(openTodos.count == 2)
+
+        let visibleTodos = try await fetchVisibleTodos(client: client, includeLogbook: true)
+        #expect(visibleTodos.count == 3)
+
+        let promptSelection = promptForTodoSelection(
+            todos: [todo, other],
+            prompt: "Choose one",
+            inputReader: { "2" }
+        )
+        #expect(promptSelection?.id == "todo-2")
+
+        let idSelection = promptForTodoSelection(
+            todos: [todo, other],
+            prompt: "Choose by id",
+            inputReader: { "todo-1" }
+        )
+        #expect(idSelection?.id == "todo-1")
+        #expect(parseFlexibleDate("tomorrow 3pm") != nil)
+    }
+
+    @Test func listSearchFilterAndShowCommandsUseRuntimeClient() async throws {
+        let todayTodo = CommandFixtures.todo(
+            id: "today-1",
+            name: "Today work",
+            tags: [CommandFixtures.docsTag],
+            notes: "Important task"
+        )
+        let inboxTodo = CommandFixtures.todo(id: "inbox-1", name: "Inbox work", project: nil)
+        let client = RecordingThingsClient()
+        client.todosForList = [
+            .today: [todayTodo],
+            .inbox: [inboxTodo],
+            .upcoming: [],
+            .anytime: [],
+            .someday: [],
+        ]
+        client.projects = [CommandFixtures.releaseProject]
+        client.areas = [CommandFixtures.workArea, CommandFixtures.personalArea]
+        client.todosByID[todayTodo.id] = todayTodo
+        client.searchResults = [todayTodo]
+
+        let todayOutput = try await runAsync(
+            try TodayCommand.parse(["--format", "{name}"]),
+            client: client
+        )
+        #expect(todayOutput.contains("Today work"))
+
+        let projectsOutput = try await runAsync(
+            try ProjectsCommand.parse(["--json"]),
+            client: client
+        )
+        #expect(projectsOutput.contains("\"name\" : \"Release\""))
+
+        let areasOutput = try await runAsync(
+            try AreasCommand.parse([]),
+            client: client
+        )
+        #expect(areasOutput.contains("Work"))
+
+        let searchOutput = try await runAsync(
+            try SearchCommand.parse(["release"]),
+            client: client
+        )
+        #expect(searchOutput.contains("Today work"))
+        #expect(client.searchQueries == ["release"])
+
+        let filterOutput = try await runAsync(
+            try FilterCommand.parse(["tags CONTAINS 'docs'"]),
+            client: client
+        )
+        #expect(filterOutput.contains("Today work"))
+        #expect(!filterOutput.contains("Inbox work"))
+
+        let showOutput = try await runAsync(
+            try ShowCommand.parse([todayTodo.id, "--json"]),
+            client: client
+        )
+        #expect(showOutput.contains("\"id\" : \"today-1\""))
+    }
+
+    @Test func addTemplateAndViewsCommandsPersistThroughConfig() async throws {
+        try await CommandTestSupport.withTemporaryConfigDirectory { _ in
+            let client = RecordingThingsClient()
+            client.createTodoID = "created-from-template"
+
+            let addParseOnlyOutput = try await runAsync(
+                try AddCommand.parse(["Ship docs tomorrow #docs", "--parse-only", "--json"]),
+                client: client
+            )
+            #expect(addParseOnlyOutput.contains("\"title\" : \"Ship docs\""))
+            #expect(addParseOnlyOutput.contains("\"tags\""))
+
+            let templateSaveOutput = try await runSync(
+                try TemplateSaveCommand.parse(["daily", "Daily review #review", "--checklist", "Inbox", "Calendar"])
+            )
+            #expect(templateSaveOutput.contains("Saved template: daily"))
+
+            let templateListOutput = try await runSync(
+                try TemplateListCommand.parse([])
+            )
+            #expect(templateListOutput.contains("daily: Daily review"))
+
+            let templateRunOutput = try await runAsync(
+                try TemplateRunCommand.parse(["daily"]),
+                client: client
+            )
+            #expect(templateRunOutput.contains("Created from template: Daily review"))
+            #expect(client.createdTodos.count == 1)
+
+            let templateDeleteOutput = try await runSync(
+                try TemplateDeleteCommand.parse(["daily"])
+            )
+            #expect(templateDeleteOutput.contains("Deleted template: daily"))
+
+            let viewsSaveOutput = try await runSync(
+                try ViewsSaveCommand.parse(["docs", "tags CONTAINS 'docs'", "--note", "Documentation work"])
+            )
+            #expect(viewsSaveOutput.contains("Saved view: docs"))
+
+            client.todosForList = [
+                .today: [CommandFixtures.todo(id: "doc-1", name: "Doc task", tags: [CommandFixtures.docsTag])],
+                .inbox: [CommandFixtures.todo(id: "other-1", name: "Other task", tags: [CommandFixtures.reviewTag])],
+                .upcoming: [],
+                .anytime: [],
+                .someday: [],
+            ]
+
+            let viewsRunOutput = try await runAsync(
+                try ViewsRunCommand.parse(["docs"]),
+                client: client
+            )
+            #expect(viewsRunOutput.contains("Doc task"))
+            #expect(!viewsRunOutput.contains("Other task"))
+
+            let viewsListOutput = try await runSync(
+                try ViewsListCommand.parse([])
+            )
+            #expect(viewsListOutput.contains("# Documentation work"))
+
+            let viewsDeleteOutput = try await runSync(
+                try ViewsDeleteCommand.parse(["docs"])
+            )
+            #expect(viewsDeleteOutput.contains("Deleted view: docs"))
+        }
+    }
+
+    @Test func completionsOutputIncludesCurrentCommandFamilies() async throws {
+        let zshOutput = try await runSync(
+            try CompletionsCommand.parse(["zsh"])
+        )
+        #expect(zshOutput.contains("'views:Manage saved filter views'"))
+        #expect(zshOutput.contains("'template:Manage reusable task templates'"))
+        #expect(zshOutput.contains("'undo:Undo the most recent supported mutation'"))
+        #expect(zshOutput.contains("'focus:Show a focused queue of high-attention tasks'"))
+        #expect(zshOutput.contains("'pick:Interactively pick a todo for a follow-up action'"))
+        #expect(zshOutput.contains("'doctor:Check clings setup and local environment'"))
+        #expect(zshOutput.contains("'audit:Audit project health and missing next actions'"))
+    }
+
+    @Test func mutationCommandsUpdateAndUndoRoundTrip() async throws {
+        try await CommandTestSupport.withTemporaryConfigDirectory { _ in
+            let baseTodo = CommandFixtures.todo(id: "todo-1", name: "Current title", tags: [CommandFixtures.docsTag], notes: "Old")
+            let alternateTodo = CommandFixtures.todo(id: "todo-2", name: "Matching title")
+            let client = RecordingThingsClient()
+            client.todosByID[baseTodo.id] = baseTodo
+            client.todosByID[alternateTodo.id] = alternateTodo
+            client.searchResults = [alternateTodo]
+
+            let completeByTitleOutput = try await runAsync(
+                try CompleteCommand.parse(["--title", "Matching"]),
+                client: client
+            )
+            #expect(completeByTitleOutput.contains("Completed: Matching title"))
+            #expect(client.completedIDs == ["todo-2"])
+
+            client.searchResults = [
+                CommandFixtures.todo(id: "multi-1", name: "Matching alpha"),
+                CommandFixtures.todo(id: "multi-2", name: "Matching beta"),
+            ]
+            let multipleMatchesOutput = try await runAsync(
+                try CompleteCommand.parse(["--title", "Matching"]),
+                client: client
+            )
+            #expect(multipleMatchesOutput.contains("Multiple todos match"))
+            #expect(multipleMatchesOutput.contains("clings complete multi-1"))
+
+            let cancelOutput = try await runAsync(
+                try CancelCommand.parse([baseTodo.id]),
+                client: client
+            )
+            #expect(cancelOutput.contains("Canceled todo: todo-1"))
+            #expect(client.canceledIDs == ["todo-1"])
+
+            let deleteOutput = try await runAsync(
+                try DeleteCommand.parse([baseTodo.id]),
+                client: client
+            )
+            #expect(deleteOutput.contains("Deleted todo: todo-1"))
+            #expect(client.deletedIDs == ["todo-1"])
+
+            try AuthTokenStore.saveToken("secret-token")
+            let recorder = URLRecorder()
+            let updateOutput = try await runAsync(
+                try UpdateCommand.parse([
+                    baseTodo.id,
+                    "--name", "Updated title",
+                    "--notes", "Updated notes",
+                    "--due", "tomorrow",
+                    "--when", "today",
+                    "--heading", "Waiting",
+                    "--tags", "docs", "urgent",
+                ]),
+                client: client,
+                openedURLs: recorder
+            )
+            #expect(updateOutput.contains("Updated todo: todo-1"))
+            #expect(client.updatedTodos.count == 1)
+            #expect(recorder.urls.count == 1)
+            #expect(recorder.urls[0].contains("things:///update"))
+            #expect(recorder.urls[0].contains("auth-token=secret-token"))
+            #expect(recorder.urls[0].contains("heading=Waiting"))
+
+            let undoShowOutput = try await runAsync(
+                try UndoCommand.parse(["--show"]),
+                client: client
+            )
+            #expect(undoShowOutput.contains("Latest undo: update todo-1"))
+
+            let undoUpdateOutput = try await runAsync(
+                try UndoCommand.parse([]),
+                client: client
+            )
+            #expect(undoUpdateOutput.contains("Undid update for todo-1"))
+
+            try UndoStore.record(UndoEntry(operation: .create, todoID: "created-id", snapshot: nil))
+            let undoCreateOutput = try await runAsync(
+                try UndoCommand.parse([]),
+                client: client
+            )
+            #expect(undoCreateOutput.contains("Undid create for created-id"))
+            #expect(client.deletedIDs.contains("created-id"))
+
+            try UndoStore.record(UndoEntry(operation: .complete, todoID: "todo-2", snapshot: TodoSnapshot(todo: alternateTodo)))
+            let undoCompleteOutput = try await runAsync(
+                try UndoCommand.parse([]),
+                client: client
+            )
+            #expect(undoCompleteOutput.contains("Undid complete for todo-2"))
+            #expect(client.reopenedIDs.contains("todo-2"))
+        }
+    }
+
+    @Test func focusPickAndProjectCommandsUseRuntimeData() async throws {
+        try await CommandTestSupport.withTemporaryConfigDirectory { _ in
+            let overdue = CommandFixtures.todo(
+                id: "focus-1",
+                name: "Overdue task",
+                dueDate: Date(timeIntervalSinceNow: -3600),
+                tags: [CommandFixtures.urgentTag]
+            )
+            let today = CommandFixtures.todo(id: "focus-2", name: "Today task", dueDate: Date())
+            let completed = CommandFixtures.todo(id: "done-1", name: "Completed task", status: .completed)
+            let client = RecordingThingsClient()
+            client.todosForList = [
+                .today: [today],
+                .inbox: [overdue],
+                .upcoming: [],
+                .anytime: [],
+                .someday: [],
+                .logbook: [completed],
+            ]
+            client.searchResults = [overdue]
+            client.todosByID[overdue.id] = overdue
+
+            let focusOutput = try await runAsync(
+                try FocusCommand.parse([]),
+                client: client
+            )
+            #expect(focusOutput.contains("Overdue task"))
+            #expect(focusOutput.contains("Overdue"))
+
+            let focusFormatOutput = try await runAsync(
+                try FocusCommand.parse(["--format", "{name}"]),
+                client: client
+            )
+            #expect(focusFormatOutput.contains("Overdue task"))
+
+            let pickShowOutput = try await runAsync(
+                try PickShowCommand.parse(["Overdue"]),
+                client: client,
+                inputs: ["1"]
+            )
+            #expect(pickShowOutput.contains("Overdue task"))
+
+            let pickCompleteOutput = try await runAsync(
+                try PickCompleteCommand.parse([]),
+                client: client,
+                inputs: ["1"]
+            )
+            #expect(pickCompleteOutput.contains("Completed: Today task") || pickCompleteOutput.contains("Completed: Overdue task"))
+            #expect(!client.completedIDs.isEmpty)
+
+            let pickCancelOutput = try await runAsync(
+                try PickCancelCommand.parse([]),
+                client: client,
+                inputs: ["1"]
+            )
+            #expect(pickCancelOutput.contains("Canceled:"))
+
+            let pickDeleteOutput = try await runAsync(
+                try PickDeleteCommand.parse([]),
+                client: client,
+                inputs: ["1"]
+            )
+            #expect(pickDeleteOutput.contains("Deleted:"))
+
+            client.projects = [CommandFixtures.releaseProject]
+            let projectListOutput = try await runAsync(
+                try ProjectListCommand.parse(["--json"]),
+                client: client
+            )
+            #expect(projectListOutput.contains("\"name\" : \"Release\""))
+
+            let projectAddOutput = try await runAsync(
+                try ProjectAddCommand.parse([
+                    "Release Readiness",
+                    "--notes", "Prepare the launch",
+                    "--area", "Work",
+                    "--when", "today",
+                    "--deadline", "2030-01-01",
+                    "--tags", "planning,research",
+                ]),
+                client: client
+            )
+            #expect(projectAddOutput.contains("Created project: Release Readiness"))
+            #expect(client.createdProjects.count == 1)
+
+            client.todosForList[.today] = [today]
+            let projectAuditOutput = try await runAsync(
+                try ProjectAuditCommand.parse(["--json"]),
+                client: client
+            )
+            #expect(projectAuditOutput.contains("\"items\""))
+        }
+    }
+
+    @Test func tagsAndBulkCommandsMutateThroughRuntimeClient() async throws {
+        let first = CommandFixtures.todo(id: "bulk-1", name: "First", tags: [CommandFixtures.docsTag], project: nil)
+        let second = CommandFixtures.todo(id: "bulk-2", name: "Second", tags: [], project: nil)
+        let client = RecordingThingsClient()
+        client.tags = [CommandFixtures.docsTag, CommandFixtures.reviewTag]
+        client.todosForList = [
+            .today: [first, second],
+            .inbox: [first, second],
+        ]
+
+        let tagsListOutput = try await runAsync(
+            try TagsListCommand.parse([]),
+            client: client
+        )
+        #expect(tagsListOutput.contains("docs"))
+
+        let tagsAddOutput = try await runAsync(
+            try TagsAddCommand.parse(["urgent"]),
+            client: client
+        )
+        #expect(tagsAddOutput.contains("Created tag: urgent"))
+        #expect(client.createdTags == ["urgent"])
+
+        let tagsDeleteOutput = try await runAsync(
+            try TagsDeleteCommand.parse(["review"]),
+            client: client,
+            inputs: ["yes"]
+        )
+        #expect(tagsDeleteOutput.contains("Deleted tag: review"))
+        #expect(client.deletedTags == ["review"])
+
+        let tagsRenameOutput = try await runAsync(
+            try TagsRenameCommand.parse(["docs", "documentation"]),
+            client: client
+        )
+        #expect(tagsRenameOutput.contains("Renamed tag: docs -> documentation"))
+        #expect(client.renamedTags.count == 1)
+
+        let bulkCompleteOutput = try await runAsync(
+            try BulkCompleteCommand.parse(["--list", "today", "--yes"]),
+            client: client
+        )
+        #expect(bulkCompleteOutput.contains("Completed: 2, Failed: 0"))
+
+        let bulkCancelOutput = try await runAsync(
+            try BulkCancelCommand.parse(["--list", "today", "--dry-run"]),
+            client: client
+        )
+        #expect(bulkCancelOutput.contains("[DRY RUN]"))
+
+        let bulkTagOutput = try await runAsync(
+            try BulkTagCommand.parse(["review", "--list", "today", "--yes"]),
+            client: client
+        )
+        #expect(bulkTagOutput.contains("Updated 2 todo(s)"))
+        #expect(client.updatedTodos.count >= 2)
+
+        let bulkMoveOutput = try await runAsync(
+            try BulkMoveCommand.parse(["--to", "Archive", "--list", "today", "--yes"]),
+            client: client
+        )
+        #expect(bulkMoveOutput.contains("Moved: 2, Failed: 0"))
+        #expect(client.movedTodos.count == 2)
+    }
+
+    @Test func doctorReviewStatsAndCompletionsCommandsReportExpectedOutput() async throws {
+        try await CommandTestSupport.withTemporaryConfigDirectory { _ in
+            try AuthTokenStore.saveToken("doctor-token")
+
+            let overdue = CommandFixtures.todo(
+                id: "stats-1",
+                name: "Overdue docs",
+                dueDate: Date(timeIntervalSinceNow: -7200),
+                tags: [CommandFixtures.docsTag],
+                notes: "Needs attention"
+            )
+            let upcoming = CommandFixtures.todo(
+                id: "stats-2",
+                name: "Upcoming review",
+                dueDate: Date(timeIntervalSinceNow: 2 * 24 * 3600),
+                tags: [CommandFixtures.reviewTag]
+            )
+            let completed = CommandFixtures.todo(
+                id: "stats-3",
+                name: "Finished docs",
+                status: .completed,
+                tags: [CommandFixtures.docsTag]
+            )
+
+            let database = MockThingsDatabase(
+                lists: [
+                    .inbox: [overdue],
+                    .today: [upcoming],
+                    .upcoming: [upcoming],
+                    .anytime: [overdue],
+                    .someday: [],
+                    .logbook: [completed],
+                ],
+                projects: [CommandFixtures.releaseProject],
+                areas: [CommandFixtures.workArea],
+                tags: [CommandFixtures.docsTag, CommandFixtures.reviewTag],
+                todosByID: [:],
+                searchResults: []
+            )
+
+            let doctorOutput = try await runSync(
+                try DoctorCommand.parse(["--json"]),
+                database: database
+            )
+            #expect(doctorOutput.contains("\"overallStatus\""))
+            #expect(doctorOutput.contains("Auth token"))
+
+            let reviewStartOutput = try await runAsync(
+                try ReviewStartCommand.parse([]),
+                database: database
+            )
+            #expect(reviewStartOutput.contains("Weekly Review"))
+            #expect(ReviewSession.load() != nil)
+
+            let reviewStatusOutput = try await runAsync(
+                try ReviewStatusCommand.parse([]),
+                database: database
+            )
+            #expect(reviewStatusOutput.contains("Review Session Status"))
+
+            let reviewClearOutput = try await runAsync(
+                try ReviewClearCommand.parse([]),
+                database: database
+            )
+            #expect(reviewClearOutput.contains("Review session cleared."))
+            #expect(ReviewSession.load() == nil)
+
+            let statsOutput = try await runAsync(
+                try StatsCommand.parse([]),
+                database: database
+            )
+            #expect(statsOutput.contains("Things 3 Statistics"))
+            #expect(statsOutput.contains("Overdue"))
+
+            let trendsOutput = try await runAsync(
+                try StatsTrendsCommand.parse(["--json"]),
+                database: database
+            )
+            #expect(trendsOutput.contains("\"completed\""))
+
+            let heatmapOutput = try await runAsync(
+                try StatsHeatmapCommand.parse(["--no-color"]),
+                database: database
+            )
+            #expect(heatmapOutput.contains("Completion Heatmap"))
+
+            let bashCompletions = try await runSync(try CompletionsCommand.parse(["bash"]))
+            #expect(bashCompletions.contains("_clings()"))
+
+            let zshCompletions = try await runSync(try CompletionsCommand.parse(["zsh"]))
+            #expect(zshCompletions.contains("#compdef clings"))
+
+            let fishCompletions = try await runSync(try CompletionsCommand.parse(["fish"]))
+            #expect(fishCompletions.contains("complete -c clings"))
+        }
+    }
+
+    private func runSync<T: ParsableCommand>(
+        _ command: T,
+        client: RecordingThingsClient? = nil,
+        database: MockThingsDatabase? = nil,
+        inputs: [String] = [],
+        openedURLs: URLRecorder? = nil
+    ) async throws -> String {
+        try await CommandTestSupport.withRuntime(
+            client: client,
+            database: database,
+            inputs: inputs,
+            openedURLs: openedURLs
+        ) {
+            var command = command
+            let (_, output) = try CommandTestSupport.captureStandardOutput {
+                try command.run()
+            }
+            return output
+        }
+    }
+
+    private func runAsync<T: AsyncParsableCommand>(
+        _ command: T,
+        client: RecordingThingsClient? = nil,
+        database: MockThingsDatabase? = nil,
+        inputs: [String] = [],
+        openedURLs: URLRecorder? = nil
+    ) async throws -> String {
+        try await CommandTestSupport.withRuntime(
+            client: client,
+            database: database,
+            inputs: inputs,
+            openedURLs: openedURLs
+        ) {
+            var command = command
+            let (_, output) = try await CommandTestSupport.captureStandardOutput {
+                try await command.run()
+            }
+            return output
+        }
+    }
+}

--- a/Tests/ClingsCLITests/CommandTestSupport.swift
+++ b/Tests/ClingsCLITests/CommandTestSupport.swift
@@ -1,0 +1,393 @@
+// CommandTestSupport.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import ClingsCore
+import Darwin
+import Foundation
+import Testing
+@testable import ClingsCLI
+
+enum CommandTestSupport {
+    private static let stdoutSemaphore = DispatchSemaphore(value: 1)
+    private static let configSemaphoreName = "/clings-tests-config-dir-lock"
+
+    private static func acquire(_ semaphore: DispatchSemaphore) {
+        semaphore.wait()
+    }
+
+    private static func release(_ semaphore: DispatchSemaphore) {
+        semaphore.signal()
+    }
+
+    private static func withConfigLock<T>(_ body: () async throws -> T) async throws -> T {
+        let semaphore = sem_open(configSemaphoreName, O_CREAT, S_IRUSR | S_IWUSR, 1)
+        precondition(semaphore != SEM_FAILED, "Failed to create shared config semaphore")
+        defer { sem_close(semaphore) }
+
+        sem_wait(semaphore)
+        defer { sem_post(semaphore) }
+
+        return try await body()
+    }
+
+    static func withTemporaryConfigDirectory<T>(_ body: (URL) async throws -> T) async throws -> T {
+        try await withConfigLock {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("clings-cli-config-\(UUID().uuidString)")
+            setenv("CLINGS_CONFIG_DIR", root.path, 1)
+            defer {
+                unsetenv("CLINGS_CONFIG_DIR")
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            return try await body(root)
+        }
+    }
+
+    static func captureStandardOutput<T>(_ body: () throws -> T) throws -> (T, String) {
+        acquire(stdoutSemaphore)
+        defer { release(stdoutSemaphore) }
+
+        let pipe = Pipe()
+        let originalStdout = dup(STDOUT_FILENO)
+        precondition(originalStdout >= 0, "Failed to duplicate stdout")
+
+        fflush(stdout)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+        do {
+            let result = try body()
+            fflush(stdout)
+            dup2(originalStdout, STDOUT_FILENO)
+            close(originalStdout)
+            try pipe.fileHandleForWriting.close()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return (result, String(data: data, encoding: .utf8) ?? "")
+        } catch {
+            fflush(stdout)
+            dup2(originalStdout, STDOUT_FILENO)
+            close(originalStdout)
+            try? pipe.fileHandleForWriting.close()
+            throw error
+        }
+    }
+
+    static func captureStandardOutput<T>(_ body: () async throws -> T) async throws -> (T, String) {
+        acquire(stdoutSemaphore)
+        defer { release(stdoutSemaphore) }
+
+        let pipe = Pipe()
+        let originalStdout = dup(STDOUT_FILENO)
+        precondition(originalStdout >= 0, "Failed to duplicate stdout")
+
+        fflush(stdout)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+        do {
+            let result = try await body()
+            fflush(stdout)
+            dup2(originalStdout, STDOUT_FILENO)
+            close(originalStdout)
+            try pipe.fileHandleForWriting.close()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return (result, String(data: data, encoding: .utf8) ?? "")
+        } catch {
+            fflush(stdout)
+            dup2(originalStdout, STDOUT_FILENO)
+            close(originalStdout)
+            try? pipe.fileHandleForWriting.close()
+            throw error
+        }
+    }
+
+    static func withRuntime<T>(
+        client: (any ThingsClientProtocol)? = nil,
+        database: (any ThingsDatabaseReadable)? = nil,
+        inputs: [String] = [],
+        openedURLs: URLRecorder? = nil,
+        body: () async throws -> T
+    ) async throws -> T {
+        let feeder = InputFeeder(inputs: inputs)
+        let currentClientFactory = CommandRuntime.makeClient
+        let currentDatabaseFactory = CommandRuntime.makeDatabase
+        let currentInputReader = CommandRuntime.inputReader
+        let currentOpenURLScheme = CommandRuntime.openURLScheme
+
+        let clientFactory: @Sendable () -> any ThingsClientProtocol = {
+            if let client {
+                return client
+            }
+            return currentClientFactory()
+        }
+
+        let databaseFactory: @Sendable () throws -> any ThingsDatabaseReadable = {
+            if let database {
+                return database
+            }
+            return try currentDatabaseFactory()
+        }
+
+        let inputReader: @Sendable () -> String? = {
+            if inputs.isEmpty {
+                return currentInputReader()
+            }
+            return feeder.read()
+        }
+
+        let openURLScheme: @Sendable (String) throws -> Void = { url in
+            if let openedURLs {
+                openedURLs.urls.append(url)
+                return
+            }
+            try currentOpenURLScheme(url)
+        }
+
+        return try await CommandRuntime.$makeClient.withValue(clientFactory) {
+            try await CommandRuntime.$makeDatabase.withValue(databaseFactory) {
+                try await CommandRuntime.$inputReader.withValue(inputReader) {
+                    try await CommandRuntime.$openURLScheme.withValue(openURLScheme) {
+                        try await body()
+                    }
+                }
+            }
+        }
+    }
+}
+
+final class URLRecorder: @unchecked Sendable {
+    var urls: [String] = []
+}
+
+private final class InputFeeder: @unchecked Sendable {
+    private var inputs: [String]
+
+    init(inputs: [String]) {
+        self.inputs = inputs
+    }
+
+    func read() -> String? {
+        guard !inputs.isEmpty else { return nil }
+        return inputs.removeFirst()
+    }
+}
+
+struct MockThingsDatabase: ThingsDatabaseReadable {
+    var lists: [ListView: [Todo]] = [:]
+    var projects: [Project] = []
+    var areas: [Area] = []
+    var tags: [ClingsCore.Tag] = []
+    var todosByID: [String: Todo] = [:]
+    var searchResults: [Todo] = []
+
+    func fetchList(_ list: ListView) throws -> [Todo] {
+        lists[list] ?? []
+    }
+
+    func fetchProjects() throws -> [Project] {
+        projects
+    }
+
+    func fetchAreas() throws -> [Area] {
+        areas
+    }
+
+    func fetchTags() throws -> [ClingsCore.Tag] {
+        tags
+    }
+
+    func fetchTodo(id: String) throws -> Todo {
+        guard let todo = todosByID[id] else {
+            throw ThingsError.notFound(id)
+        }
+        return todo
+    }
+
+    func search(query: String) throws -> [Todo] {
+        searchResults
+    }
+}
+
+final class RecordingThingsClient: ThingsClientProtocol, @unchecked Sendable {
+    var todosForList: [ListView: [Todo]] = [:]
+    var projects: [Project] = []
+    var areas: [Area] = []
+    var tags: [ClingsCore.Tag] = []
+    var todosByID: [String: Todo] = [:]
+    var searchResults: [Todo] = []
+    var createTodoID = "created-todo-id"
+    var createProjectID = "created-project-id"
+    var error: Error?
+
+    private(set) var fetchedLists: [ListView] = []
+    private(set) var completedIDs: [String] = []
+    private(set) var reopenedIDs: [String] = []
+    private(set) var canceledIDs: [String] = []
+    private(set) var deletedIDs: [String] = []
+    private(set) var movedTodos: [(String, String)] = []
+    private(set) var updatedTodos: [(String, String?, String?, Date?, [String]?)] = []
+    private(set) var createdTodos: [(String, String?, Date?, Date?, [String], String?, String?, [String])] = []
+    private(set) var createdProjects: [(String, String?, Date?, Date?, [String], String?)] = []
+    private(set) var searchQueries: [String] = []
+    private(set) var createdTags: [String] = []
+    private(set) var deletedTags: [String] = []
+    private(set) var renamedTags: [(String, String)] = []
+
+    func fetchList(_ list: ListView) async throws -> [Todo] {
+        if let error { throw error }
+        fetchedLists.append(list)
+        return todosForList[list] ?? []
+    }
+
+    func fetchProjects() async throws -> [Project] {
+        if let error { throw error }
+        return projects
+    }
+
+    func fetchAreas() async throws -> [Area] {
+        if let error { throw error }
+        return areas
+    }
+
+    func fetchTags() async throws -> [ClingsCore.Tag] {
+        if let error { throw error }
+        return tags
+    }
+
+    func fetchTodo(id: String) async throws -> Todo {
+        if let error { throw error }
+        guard let todo = todosByID[id] else {
+            throw ThingsError.notFound(id)
+        }
+        return todo
+    }
+
+    func createTodo(
+        name: String,
+        notes: String?,
+        when: Date?,
+        deadline: Date?,
+        tags: [String],
+        project: String?,
+        area: String?,
+        checklistItems: [String]
+    ) async throws -> String {
+        if let error { throw error }
+        createdTodos.append((name, notes, when, deadline, tags, project, area, checklistItems))
+        return createTodoID
+    }
+
+    func createProject(
+        name: String,
+        notes: String?,
+        when: Date?,
+        deadline: Date?,
+        tags: [String],
+        area: String?
+    ) async throws -> String {
+        if let error { throw error }
+        createdProjects.append((name, notes, when, deadline, tags, area))
+        return createProjectID
+    }
+
+    func completeTodo(id: String) async throws {
+        if let error { throw error }
+        completedIDs.append(id)
+    }
+
+    func reopenTodo(id: String) async throws {
+        if let error { throw error }
+        reopenedIDs.append(id)
+    }
+
+    func cancelTodo(id: String) async throws {
+        if let error { throw error }
+        canceledIDs.append(id)
+    }
+
+    func deleteTodo(id: String) async throws {
+        if let error { throw error }
+        deletedIDs.append(id)
+    }
+
+    func moveTodo(id: String, toProject projectName: String) async throws {
+        if let error { throw error }
+        movedTodos.append((id, projectName))
+    }
+
+    func updateTodo(id: String, name: String?, notes: String?, dueDate: Date?, tags: [String]?) async throws {
+        if let error { throw error }
+        updatedTodos.append((id, name, notes, dueDate, tags))
+    }
+
+    func search(query: String) async throws -> [Todo] {
+        if let error { throw error }
+        searchQueries.append(query)
+        return searchResults
+    }
+
+    func createTag(name: String) async throws -> ClingsCore.Tag {
+        if let error { throw error }
+        createdTags.append(name)
+        return ClingsCore.Tag(id: "tag-\(name)", name: name)
+    }
+
+    func deleteTag(name: String) async throws {
+        if let error { throw error }
+        deletedTags.append(name)
+    }
+
+    func renameTag(oldName: String, newName: String) async throws {
+        if let error { throw error }
+        renamedTags.append((oldName, newName))
+    }
+
+    func openInThings(id: String) throws {}
+    func openInThings(list: ListView) throws {}
+}
+
+enum CommandFixtures {
+    static let workArea = Area(id: "area-work", name: "Work", tags: [])
+    static let personalArea = Area(id: "area-personal", name: "Personal", tags: [])
+    static let docsTag = ClingsCore.Tag(id: "tag-docs", name: "docs")
+    static let urgentTag = ClingsCore.Tag(id: "tag-urgent", name: "urgent")
+    static let reviewTag = ClingsCore.Tag(id: "tag-review", name: "review")
+
+    static let releaseProject = Project(
+        id: "project-release",
+        name: "Release",
+        notes: "Ship it",
+        status: .open,
+        area: workArea,
+        tags: [docsTag],
+        dueDate: nil,
+        creationDate: Date(timeIntervalSinceReferenceDate: 1000)
+    )
+
+    static func todo(
+        id: String,
+        name: String,
+        status: Status = .open,
+        dueDate: Date? = nil,
+        tags: [ClingsCore.Tag] = [],
+        project: Project? = releaseProject,
+        area: Area? = workArea,
+        notes: String? = nil,
+        checklistItems: [ChecklistItem] = []
+    ) -> Todo {
+        Todo(
+            id: id,
+            name: name,
+            notes: notes,
+            status: status,
+            dueDate: dueDate,
+            tags: tags,
+            project: project,
+            area: area,
+            checklistItems: checklistItems,
+            creationDate: Date(timeIntervalSinceReferenceDate: 1000),
+            modificationDate: Date(timeIntervalSinceReferenceDate: 2000)
+        )
+    }
+}

--- a/Tests/ClingsCoreTests/Analysis/FocusPlannerTests.swift
+++ b/Tests/ClingsCoreTests/Analysis/FocusPlannerTests.swift
@@ -1,0 +1,23 @@
+// FocusPlannerTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("FocusPlanner")
+struct FocusPlannerTests {
+    @Test func ranksOverdueAndUrgentItemsFirst() {
+        let plan = FocusPlanner().build(
+            todos: [TestData.todoOpen, TestData.todoOverdue, TestData.todoNoProject],
+            limit: 3,
+            referenceDate: Date()
+        )
+
+        #expect(plan.items.count == 3)
+        #expect(plan.items.first?.todo.id == TestData.todoOverdue.id)
+        #expect(plan.items.first?.reasons.contains("Overdue") == true)
+    }
+}

--- a/Tests/ClingsCoreTests/Analysis/ProjectAuditTests.swift
+++ b/Tests/ClingsCoreTests/Analysis/ProjectAuditTests.swift
@@ -1,0 +1,34 @@
+// ProjectAuditTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("ProjectAudit")
+struct ProjectAuditTests {
+    @Test func flagsProjectsWithNoNextActionsAndOverdueWork() {
+        let report = ProjectAudit().audit(
+            projects: [TestData.projectAlpha],
+            todos: [TestData.todoOverdue],
+            referenceDate: Date()
+        )
+
+        #expect(report.items.count == 1)
+        #expect(report.items[0].overdueCount == 1)
+        #expect(report.items[0].findings.contains("Overdue tasks"))
+    }
+
+    @Test func flagsProjectsWithNoOpenTodos() {
+        let report = ProjectAudit().audit(
+            projects: [TestData.projectAlpha],
+            todos: [],
+            referenceDate: Date()
+        )
+
+        #expect(report.items.first?.findings.contains("No next actions") == true)
+        #expect(report.summary.projectsWithoutNextActions == 1)
+    }
+}

--- a/Tests/ClingsCoreTests/Analysis/ReviewAssistantTests.swift
+++ b/Tests/ClingsCoreTests/Analysis/ReviewAssistantTests.swift
@@ -1,0 +1,27 @@
+// ReviewAssistantTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("ReviewAssistant")
+struct ReviewAssistantTests {
+    @Test func summarizesBacklogDeadlinesAndSuggestions() {
+        let summary = ReviewAssistant().summarize(
+            inbox: [TestData.todoNoProject],
+            someday: [TestData.todoWithChecklist],
+            today: [TestData.todoOpen],
+            upcoming: [TestData.todoOverdue],
+            projects: [TestData.projectAlpha],
+            referenceDate: Date()
+        )
+
+        #expect(summary.inboxCount == 1)
+        #expect(summary.somedayCount == 1)
+        #expect(summary.upcomingDeadlines.count >= 1)
+        #expect(summary.suggestedActions.contains(where: { $0.contains("Inbox") }))
+    }
+}

--- a/Tests/ClingsCoreTests/Config/AuthTokenStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/AuthTokenStoreTests.swift
@@ -11,41 +11,25 @@ import Testing
 /// save and restore the original value to avoid clobbering real config.
 @Suite("AuthTokenStore", .serialized)
 struct AuthTokenStoreTests {
-
-    private static let tokenPath = FileManager.default.homeDirectoryForCurrentUser
-        .appendingPathComponent(".config/clings/auth-token")
-
-    /// Read the current token file contents (raw bytes), or nil if missing.
-    private static func backupToken() -> Data? {
-        try? Data(contentsOf: tokenPath)
-    }
-
-    /// Restore the token file to its previous state.
-    private static func restoreToken(_ backup: Data?) {
-        if let backup = backup {
-            try? backup.write(to: tokenPath)
-            // Re-enforce 0600 permissions
-            let fd = open(tokenPath.path, O_WRONLY, 0o600)
-            if fd >= 0 {
-                fchmod(fd, 0o600)
-                close(fd)
-            }
-        } else {
-            try? FileManager.default.removeItem(at: tokenPath)
-        }
+    private static func tokenPath() throws -> URL {
+        try ClingsConfig.fileURL(named: "auth-token")
     }
 
     @Suite("saveToken validation")
     struct SaveTokenValidation {
         @Test func rejectsEmptyToken() {
-            #expect(throws: (any Error).self) {
-                try AuthTokenStore.saveToken("")
+            try? ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                #expect(throws: (any Error).self) {
+                    try AuthTokenStore.saveToken("")
+                }
             }
         }
 
         @Test func rejectsWhitespaceOnlyToken() {
-            #expect(throws: (any Error).self) {
-                try AuthTokenStore.saveToken("   \n\t  ")
+            try? ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                #expect(throws: (any Error).self) {
+                    try AuthTokenStore.saveToken("   \n\t  ")
+                }
             }
         }
     }
@@ -53,59 +37,54 @@ struct AuthTokenStoreTests {
     @Suite("saveToken and loadToken round-trip", .serialized)
     struct RoundTrip {
         @Test func savesAndLoadsToken() throws {
-            let backup = AuthTokenStoreTests.backupToken()
-            defer { AuthTokenStoreTests.restoreToken(backup) }
-
-            let testToken = "test-token-\(UUID().uuidString)"
-            try AuthTokenStore.saveToken(testToken)
-            let loaded = try AuthTokenStore.loadToken()
-            #expect(loaded == testToken)
+            try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                let testToken = "test-token-\(UUID().uuidString)"
+                try AuthTokenStore.saveToken(testToken)
+                let loaded = try AuthTokenStore.loadToken()
+                #expect(loaded == testToken)
+            }
         }
 
         @Test func trimsWhitespace() throws {
-            let backup = AuthTokenStoreTests.backupToken()
-            defer { AuthTokenStoreTests.restoreToken(backup) }
-
-            let core = "trimmed-token-\(UUID().uuidString)"
-            let testToken = "  \(core)  \n"
-            try AuthTokenStore.saveToken(testToken)
-            let loaded = try AuthTokenStore.loadToken()
-            #expect(loaded == core)
+            try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                let core = "trimmed-token-\(UUID().uuidString)"
+                let testToken = "  \(core)  \n"
+                try AuthTokenStore.saveToken(testToken)
+                let loaded = try AuthTokenStore.loadToken()
+                #expect(loaded == core)
+            }
         }
 
         @Test func setsRestrictedPermissions() throws {
-            let backup = AuthTokenStoreTests.backupToken()
-            defer { AuthTokenStoreTests.restoreToken(backup) }
-
-            try AuthTokenStore.saveToken("perm-test-\(UUID().uuidString)")
-            let attrs = try FileManager.default.attributesOfItem(atPath: AuthTokenStoreTests.tokenPath.path)
-            let perms = (attrs[.posixPermissions] as? Int) ?? 0
-            #expect(perms == 0o600)
+            try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                try AuthTokenStore.saveToken("perm-test-\(UUID().uuidString)")
+                let attrs = try FileManager.default.attributesOfItem(atPath: AuthTokenStoreTests.tokenPath().path)
+                let perms = (attrs[.posixPermissions] as? Int) ?? 0
+                #expect(perms == 0o600)
+            }
         }
 
         @Test func overwritesPreviousToken() throws {
-            let backup = AuthTokenStoreTests.backupToken()
-            defer { AuthTokenStoreTests.restoreToken(backup) }
-
-            let first = "first-\(UUID().uuidString)"
-            let second = "second-\(UUID().uuidString)"
-            try AuthTokenStore.saveToken(first)
-            try AuthTokenStore.saveToken(second)
-            let loaded = try AuthTokenStore.loadToken()
-            #expect(loaded == second)
+            try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                let first = "first-\(UUID().uuidString)"
+                let second = "second-\(UUID().uuidString)"
+                try AuthTokenStore.saveToken(first)
+                try AuthTokenStore.saveToken(second)
+                let loaded = try AuthTokenStore.loadToken()
+                #expect(loaded == second)
+            }
         }
     }
 
     @Suite("loadToken errors")
     struct LoadTokenErrors {
         @Test func throwsWhenTokenFileIsEmpty() throws {
-            let backup = AuthTokenStoreTests.backupToken()
-            defer { AuthTokenStoreTests.restoreToken(backup) }
-
-            // Write an empty file (bypassing saveToken which rejects empty)
-            try Data().write(to: AuthTokenStoreTests.tokenPath)
-            #expect(throws: (any Error).self) {
-                _ = try AuthTokenStore.loadToken()
+            try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+                // Write an empty file (bypassing saveToken which rejects empty)
+                try Data().write(to: try AuthTokenStoreTests.tokenPath())
+                #expect(throws: (any Error).self) {
+                    _ = try AuthTokenStore.loadToken()
+                }
             }
         }
     }

--- a/Tests/ClingsCoreTests/Config/ConfigTestSupport.swift
+++ b/Tests/ClingsCoreTests/Config/ConfigTestSupport.swift
@@ -1,0 +1,36 @@
+// ConfigTestSupport.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Darwin
+
+enum ConfigTestSupport {
+    private static let semaphoreName = "/clings-tests-config-dir-lock"
+
+    private static func withConfigLock<T>(_ body: () throws -> T) rethrows -> T {
+        let semaphore = sem_open(semaphoreName, O_CREAT, S_IRUSR | S_IWUSR, 1)
+        precondition(semaphore != SEM_FAILED, "Failed to create shared config semaphore")
+        defer { sem_close(semaphore) }
+
+        sem_wait(semaphore)
+        defer { sem_post(semaphore) }
+
+        return try body()
+    }
+
+    static func withTemporaryConfigDirectory(_ body: (URL) throws -> Void) throws {
+        try withConfigLock {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("clings-config-\(UUID().uuidString)")
+            setenv("CLINGS_CONFIG_DIR", root.path, 1)
+            defer {
+                unsetenv("CLINGS_CONFIG_DIR")
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            try body(root)
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/Config/JSONFileStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/JSONFileStoreTests.swift
@@ -1,0 +1,42 @@
+// JSONFileStoreTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("JSONFileStore", .serialized)
+struct JSONFileStoreTests {
+    struct Fixture: Codable, Equatable {
+        var name: String
+        var count: Int
+    }
+
+    @Test func usesEnvironmentOverrideForConfigDirectory() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { root in
+            #expect(ClingsConfig.directoryURL.standardizedFileURL.path == root.standardizedFileURL.path)
+            let ensured = try ClingsConfig.ensureDirectory()
+            #expect(ensured.standardizedFileURL.path == root.standardizedFileURL.path)
+            #expect(FileManager.default.fileExists(atPath: root.path))
+        }
+    }
+
+    @Test func savesAndLoadsCodableValues() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let fixture = Fixture(name: "views", count: 3)
+            try JSONFileStore.save(fixture, to: "fixture.json")
+
+            let loaded = try JSONFileStore.load(Fixture.self, from: "fixture.json", default: Fixture(name: "default", count: 0))
+            #expect(loaded == fixture)
+        }
+    }
+
+    @Test func returnsDefaultWhenFileIsMissing() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let loaded = try JSONFileStore.load(Fixture.self, from: "missing.json", default: Fixture(name: "fallback", count: 9))
+            #expect(loaded == Fixture(name: "fallback", count: 9))
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/Config/SavedViewStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/SavedViewStoreTests.swift
@@ -1,0 +1,40 @@
+// SavedViewStoreTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("SavedViewStore", .serialized)
+struct SavedViewStoreTests {
+    @Test func savesLoadsListsAndDeletesViews() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let view = SavedView(name: "work-today", expression: "area = 'Work' AND due <= today", note: "Daily work queue")
+            try SavedViewStore.save(view)
+
+            let loaded = try SavedViewStore.load(name: "work-today")
+            #expect(loaded?.name == "work-today")
+            #expect(loaded?.expression == "area = 'Work' AND due <= today")
+
+            let listed = try SavedViewStore.list()
+            #expect(listed.count == 1)
+            #expect(listed.first?.note == "Daily work queue")
+
+            #expect(try SavedViewStore.delete(name: "work-today"))
+            #expect((try SavedViewStore.load(name: "work-today")) == nil)
+        }
+    }
+
+    @Test func saveReplacesExistingViewWithSameName() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            try SavedViewStore.save(SavedView(name: "today", expression: "status = open"))
+            try SavedViewStore.save(SavedView(name: "today", expression: "due <= today"))
+
+            let listed = try SavedViewStore.list()
+            #expect(listed.count == 1)
+            #expect(listed.first?.expression == "due <= today")
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/Config/TemplateStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/TemplateStoreTests.swift
@@ -1,0 +1,40 @@
+// TemplateStoreTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("TemplateStore", .serialized)
+struct TemplateStoreTests {
+    @Test func savesAndLoadsRelativeTemplateExpressions() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let template = TaskTemplate(
+                name: "weekly-review",
+                title: "Weekly review",
+                notes: "Check inbox and projects",
+                tags: ["planning"],
+                project: "Operations",
+                area: "Work",
+                whenExpression: "tomorrow morning",
+                deadlineExpression: "next friday",
+                checklistItems: ["Process inbox", "Review deadlines"]
+            )
+            try TemplateStore.save(template)
+
+            let loaded = try TemplateStore.load(name: "weekly-review")
+            #expect(loaded?.whenExpression == "tomorrow morning")
+            #expect(loaded?.deadlineExpression == "next friday")
+            #expect(loaded?.checklistItems == ["Process inbox", "Review deadlines"])
+        }
+    }
+
+    @Test func deleteReturnsFalseWhenTemplateDoesNotExist() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let deleted = try TemplateStore.delete(name: "missing-template")
+            #expect(!deleted)
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/Config/TemplateStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/TemplateStoreTests.swift
@@ -16,8 +16,8 @@ struct TemplateStoreTests {
                 title: "Weekly review",
                 notes: "Check inbox and projects",
                 tags: ["planning"],
-                project: "Operations",
-                area: "Work",
+                project: "Documentation",
+                area: "Writing",
                 whenExpression: "tomorrow morning",
                 deadlineExpression: "next friday",
                 checklistItems: ["Process inbox", "Review deadlines"]

--- a/Tests/ClingsCoreTests/Config/UndoStoreTests.swift
+++ b/Tests/ClingsCoreTests/Config/UndoStoreTests.swift
@@ -1,0 +1,51 @@
+// UndoStoreTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("UndoStore", .serialized)
+struct UndoStoreTests {
+    @Test func recordsAndPopsMostRecentEntry() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            let snapshot = TodoSnapshot(
+                id: TestData.todoOpen.id,
+                name: TestData.todoOpen.name,
+                notes: TestData.todoOpen.notes,
+                dueDate: TestData.todoOpen.dueDate,
+                tags: TestData.todoOpen.tags.map(\.name),
+                status: TestData.todoOpen.status,
+                projectName: TestData.todoOpen.project?.name,
+                areaName: TestData.todoOpen.area?.name
+            )
+            let entry = UndoEntry(
+                operation: .update,
+                todoID: TestData.todoOpen.id,
+                snapshot: snapshot
+            )
+
+            try UndoStore.record(entry)
+            #expect((try UndoStore.latest())?.operation == .update)
+
+            let popped = try UndoStore.popLatest()
+            #expect(popped?.todoID == TestData.todoOpen.id)
+            #expect((try UndoStore.latest()) == nil)
+        }
+    }
+
+    @Test func keepsOnlyMostRecentEntries() throws {
+        try ConfigTestSupport.withTemporaryConfigDirectory { _ in
+            for index in 0..<30 {
+                try UndoStore.record(UndoEntry(operation: .complete, todoID: "todo-\(index)", snapshot: nil))
+            }
+
+            let entries = try UndoStore.list()
+            #expect(entries.count == 20)
+            #expect(entries.first?.todoID == "todo-29")
+            #expect(entries.last?.todoID == "todo-10")
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/Filter/FilterParserTests.swift
+++ b/Tests/ClingsCoreTests/Filter/FilterParserTests.swift
@@ -288,10 +288,9 @@ struct FilterParserTests {
                 try FilterParser.parse("NOT status = completed"),
             ]
 
-            for expr in exprs {
-                // Should not throw
-                #expect(expr != nil)
-            }
+            #expect(String(describing: exprs[0]) == String(describing: exprs[1]))
+            #expect(String(describing: exprs[2]) == String(describing: exprs[3]))
+            #expect(String(describing: exprs[4]) == String(describing: exprs[5]))
         }
     }
 
@@ -335,8 +334,11 @@ struct FilterParserTests {
                 "status = open AND (tags CONTAINS 'urgent' OR project IS NOT NULL) AND due <= tomorrow"
             )
 
-            // Just verify it parses without error
-            #expect(expr != nil)
+            if case .compound = expr {
+                // Expected compound expression
+            } else {
+                Issue.record("Expected compound expression")
+            }
         }
 
         @Test func multipleAndConditions() throws {

--- a/Tests/ClingsCoreTests/Mocks/MockThingsClient.swift
+++ b/Tests/ClingsCoreTests/Mocks/MockThingsClient.swift
@@ -41,6 +41,9 @@ final class MockThingsClient: ThingsClientProtocol, @unchecked Sendable {
     /// Track which todo IDs were completed.
     private(set) var completedIds: [String] = []
 
+    /// Track which todo IDs were reopened.
+    private(set) var reopenedIds: [String] = []
+
     /// Track which todo IDs were canceled.
     private(set) var canceledIds: [String] = []
 
@@ -134,6 +137,11 @@ final class MockThingsClient: ThingsClientProtocol, @unchecked Sendable {
         completedIds.append(id)
     }
 
+    func reopenTodo(id: String) async throws {
+        if let error = errorToThrow { throw error }
+        reopenedIds.append(id)
+    }
+
     func cancelTodo(id: String) async throws {
         if let error = errorToThrow { throw error }
         canceledIds.append(id)
@@ -203,6 +211,7 @@ final class MockThingsClient: ThingsClientProtocol, @unchecked Sendable {
     func reset() {
         fetchedLists = []
         completedIds = []
+        reopenedIds = []
         canceledIds = []
         deletedIds = []
         moveOperations = []

--- a/Tests/ClingsCoreTests/NLP/NaturalLanguageDateParserTests.swift
+++ b/Tests/ClingsCoreTests/NLP/NaturalLanguageDateParserTests.swift
@@ -1,0 +1,34 @@
+// NaturalLanguageDateParserTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("NaturalLanguageDateParser")
+struct NaturalLanguageDateParserTests {
+    let parser = NaturalLanguageDateParser()
+
+    @Test func parsesMonthAndDayWithoutYear() {
+        let result = parser.parse("dec 15")
+        #expect(result != nil)
+    }
+
+    @Test func parsesRelativeDateWithTime() {
+        let result = parser.parse("tomorrow 3pm")
+        #expect(result != nil)
+
+        let hour = Calendar.current.component(.hour, from: result!)
+        #expect(hour == 15)
+    }
+
+    @Test func parsesEveningKeyword() {
+        let result = parser.parse("this evening")
+        #expect(result != nil)
+
+        let hour = Calendar.current.component(.hour, from: result!)
+        #expect(hour == 18)
+    }
+}

--- a/Tests/ClingsCoreTests/NLP/TaskParserTests.swift
+++ b/Tests/ClingsCoreTests/NLP/TaskParserTests.swift
@@ -138,6 +138,12 @@ struct TaskParserTests {
             #expect(result.project == nil)
             #expect(result.title.contains("Looking for something"))
         }
+
+        @Test func quotedProjectExtraction() {
+            let result = parser.parse("Review notes for \"Migration Sprint\"")
+            #expect(result.project == "Migration Sprint")
+            #expect(result.title == "Review notes")
+        }
     }
 
     @Suite("Area Extraction")
@@ -160,6 +166,12 @@ struct TaskParserTests {
             let result = parser.parse("Task in 3 days")
             #expect(result.area == nil)
             #expect(result.whenDate != nil)
+        }
+
+        @Test func quotedAreaExtraction() {
+            let result = parser.parse("Draft plan in \"Deep Work\"")
+            #expect(result.area == "Deep Work")
+            #expect(result.title == "Draft plan")
         }
     }
 
@@ -230,6 +242,11 @@ struct TaskParserTests {
             let calendar = Calendar.current
             let weekday = calendar.component(.weekday, from: result.whenDate!)
             #expect(weekday == 2) // Monday = 2
+        }
+
+        @Test func whenDateMonthDayWithTime() {
+            let result = parser.parse("Demo dec 15 3pm")
+            #expect(result.whenDate != nil)
         }
     }
 

--- a/Tests/ClingsCoreTests/Output/TodoLineFormatterTests.swift
+++ b/Tests/ClingsCoreTests/Output/TodoLineFormatterTests.swift
@@ -1,0 +1,27 @@
+// TodoLineFormatterTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Testing
+@testable import ClingsCore
+
+@Suite("TodoLineFormatter")
+struct TodoLineFormatterTests {
+    @Test func replacesKnownPlaceholders() {
+        let formatter = TodoLineFormatter(template: "{status} {name} [{project}] {tags}")
+        let output = formatter.format(todo: TestData.todoOverdue)
+
+        #expect(output.contains("open"))
+        #expect(output.contains(TestData.todoOverdue.name))
+        #expect(output.contains("[Project Alpha]"))
+        #expect(output.contains("#urgent"))
+    }
+
+    @Test func missingFieldsResolveToEmptyStrings() {
+        let formatter = TodoLineFormatter(template: "{project}|{area}|{due}")
+        let output = formatter.format(todo: TestData.todoNoProject)
+
+        #expect(output.contains("|Personal|"))
+    }
+}

--- a/Tests/ClingsCoreTests/ThingsClient/HybridThingsClientTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/HybridThingsClientTests.swift
@@ -1,0 +1,201 @@
+// HybridThingsClientTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("HybridThingsClient")
+struct HybridThingsClientTests {
+    @Test func readMethodsUseDatabaseLayer() async throws {
+        let database = MockThingsDatabaseReader()
+        database.lists = [.today: [TestData.todoOpen]]
+        database.projects = [TestData.projectAlpha]
+        database.areas = [TestData.workArea]
+        database.tags = [TestData.workTag]
+        database.todosByID = [TestData.todoOpen.id: TestData.todoOpen]
+        database.searchResults = [TestData.todoNoProject]
+
+        let client = HybridThingsClient(database: database, jxaBridge: MockJXAExecutor())
+
+        let list = try await client.fetchList(.today)
+        let projects = try await client.fetchProjects()
+        let areas = try await client.fetchAreas()
+        let tags = try await client.fetchTags()
+        let todo = try await client.fetchTodo(id: TestData.todoOpen.id)
+        let searchResults = try await client.search(query: "home")
+
+        #expect(list == [TestData.todoOpen])
+        #expect(projects == [TestData.projectAlpha])
+        #expect(areas == [TestData.workArea])
+        #expect(tags == [TestData.workTag])
+        #expect(todo == TestData.todoOpen)
+        #expect(searchResults == [TestData.todoNoProject])
+        #expect(database.fetchedLists == [.today])
+        #expect(database.fetchedTodoIDs == [TestData.todoOpen.id])
+        #expect(database.searchQueries == ["home"])
+    }
+
+    @Test func writeMethodsUseBridgeAndApplyTagScripts() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.appleScriptResponses = [
+            .success("todo-id"),
+            .success("ok"),
+            .success("ok"),
+            .success("ok"),
+            .success("tag-id"),
+            .success(""),
+            .success(""),
+        ]
+        bridge.jsonResponses = [
+            .success(try creationResultJSON(success: true, id: "project-id", name: "Ops")),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+        ]
+
+        let client = HybridThingsClient(database: MockThingsDatabaseReader(), jxaBridge: bridge)
+
+        let todoID = try await client.createTodo(
+            name: "Ship docs",
+            notes: "Publish help",
+            when: Date(timeIntervalSinceReferenceDate: 10),
+            deadline: Date(timeIntervalSinceReferenceDate: 20),
+            tags: ["docs"],
+            project: "Project Alpha",
+            area: "Work",
+            checklistItems: ["Draft"]
+        )
+        let projectID = try await client.createProject(
+            name: "Ops",
+            notes: "Runbook",
+            when: Date(timeIntervalSinceReferenceDate: 30),
+            deadline: Date(timeIntervalSinceReferenceDate: 40),
+            tags: ["ops"],
+            area: "Work"
+        )
+        try await client.completeTodo(id: "todo-id")
+        try await client.reopenTodo(id: "todo-id")
+        try await client.cancelTodo(id: "todo-id")
+        try await client.deleteTodo(id: "todo-id")
+        try await client.moveTodo(id: "todo-id", toProject: "Ops")
+        try await client.updateTodo(
+            id: "todo-id",
+            name: "Renamed",
+            notes: "Updated",
+            dueDate: Date(timeIntervalSinceReferenceDate: 50),
+            tags: ["docs"]
+        )
+        let tag = try await client.createTag(name: "docs")
+        try await client.deleteTag(name: "docs")
+        try await client.renameTag(oldName: "docs", newName: "guides")
+
+        #expect(todoID == "todo-id")
+        #expect(projectID == "project-id")
+        #expect(tag == Tag(id: "tag-id", name: "docs"))
+        #expect(bridge.executeJSONScripts.count == 7)
+        #expect(bridge.appleScriptScripts.count == 7)
+        #expect(bridge.appleScriptScripts[1].contains("docs"))
+        #expect(bridge.executeJSONScripts[6].contains("Renamed"))
+    }
+
+    @Test func writeMethodsPropagateFailures() async throws {
+        let missingIDBridge = MockJXAExecutor()
+        missingIDBridge.appleScriptResponses = [.success("")]
+
+        let missingIDClient = HybridThingsClient(database: MockThingsDatabaseReader(), jxaBridge: missingIDBridge)
+        do {
+            _ = try await missingIDClient.createTodo(
+                name: "Broken",
+                notes: nil,
+                when: nil,
+                deadline: nil,
+                tags: [],
+                project: nil,
+                area: nil,
+                checklistItems: []
+            )
+            Issue.record("Expected missing todo ID error")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message.contains("Missing created todo ID"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let failedMutationBridge = MockJXAExecutor()
+        failedMutationBridge.jsonResponses = [.success(try mutationResultJSON(success: false, error: "nope"))]
+        let failedMutationClient = HybridThingsClient(database: MockThingsDatabaseReader(), jxaBridge: failedMutationBridge)
+        do {
+            try await failedMutationClient.completeTodo(id: "todo-id")
+            Issue.record("Expected mutation failure")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message == "nope")
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let tagFailureBridge = MockJXAExecutor()
+        tagFailureBridge.appleScriptResponses = [.failure(JXAError.scriptError("tag failure"))]
+        let tagFailureClient = HybridThingsClient(database: MockThingsDatabaseReader(), jxaBridge: tagFailureBridge)
+        do {
+            try await tagFailureClient.deleteTag(name: "docs")
+            Issue.record("Expected deleteTag failure")
+        } catch let error as ThingsError {
+            switch error {
+            case .jxaError(let jxaError):
+                #expect(jxaError.localizedDescription.contains("tag failure"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func openCommandsAreDisabled() {
+        let client = HybridThingsClient(database: MockThingsDatabaseReader(), jxaBridge: MockJXAExecutor())
+
+        do {
+            try client.openInThings(id: "todo-id")
+            Issue.record("Expected openInThings(id:) to throw")
+        } catch let error as ThingsError {
+            switch error {
+            case .invalidState(let message):
+                #expect(message.contains("Open command is disabled"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        do {
+            try client.openInThings(list: .today)
+            Issue.record("Expected openInThings(list:) to throw")
+        } catch let error as ThingsError {
+            switch error {
+            case .invalidState(let message):
+                #expect(message.contains("Open command is disabled"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/ThingsClient/JXABridgeTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/JXABridgeTests.swift
@@ -1,0 +1,164 @@
+// JXABridgeTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("JXABridge", .serialized)
+struct JXABridgeTests {
+    private struct Payload: Decodable {
+        let value: Int
+        let date: Date
+    }
+
+    @Test func executeReturnsTrimmedOutput() async throws {
+        let bridge = JXABridge(timeout: 1)
+        let output = try await bridge.execute("(() => '  trimmed output  ')()")
+        #expect(output == "trimmed output")
+    }
+
+    @Test func executeJSONDecodesMultipleDateFormats() async throws {
+        let bridge = JXABridge(timeout: 1)
+
+        let isoPayload = try await bridge.executeJSON(
+            "JSON.stringify({ value: 1, date: '2024-12-25T00:00:00Z' })",
+            as: Payload.self
+        )
+        let fractionalPayload = try await bridge.executeJSON(
+            "JSON.stringify({ value: 2, date: '2024-12-25T00:00:00.123Z' })",
+            as: Payload.self
+        )
+        let simplePayload = try await bridge.executeJSON(
+            "JSON.stringify({ value: 3, date: '2024-12-25' })",
+            as: Payload.self
+        )
+
+        #expect(isoPayload.value == 1)
+        #expect(fractionalPayload.value == 2)
+        #expect(simplePayload.value == 3)
+
+        let calendar = Calendar(identifier: .gregorian)
+        let components = calendar.dateComponents([.year, .month, .day], from: simplePayload.date)
+        #expect(components.year == 2024)
+        #expect(components.month == 12)
+        #expect(components.day == 25)
+    }
+
+    @Test func executeJSONThrowsHelpfulInvalidJSONErrors() async throws {
+        let bridge = JXABridge(timeout: 1)
+
+        do {
+            _ = try await bridge.executeJSON("\"\"", as: Payload.self)
+            Issue.record("Expected empty JSON response to fail")
+        } catch let error as JXAError {
+            switch error {
+            case .invalidJSON(let message):
+                #expect(message.contains("Empty response"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        do {
+            _ = try await bridge.executeJSON("JSON.stringify({ value: 1, date: 'not-a-date' })", as: Payload.self)
+            Issue.record("Expected bad date to fail")
+        } catch let error as JXAError {
+            switch error {
+            case .invalidJSON(let message):
+                #expect(message.contains("Decoding error"))
+                #expect(message.contains("Raw output"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func executeAndExecuteAppleScriptSurfaceProcessErrors() async throws {
+        let bridge = JXABridge(timeout: 1)
+
+        do {
+            _ = try await bridge.execute("(() => { throw new Error('boom'); })()")
+            Issue.record("Expected JXA process error")
+        } catch let error as JXAError {
+            switch error {
+            case .processError(let code, let message):
+                #expect(code != 0)
+                #expect(message.contains("boom"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        do {
+            _ = try await bridge.executeAppleScript("error \"boom\"")
+            Issue.record("Expected AppleScript process error")
+        } catch let error as JXAError {
+            switch error {
+            case .processError(let code, let message):
+                #expect(code != 0)
+                #expect(message.contains("boom"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func executeAndAppleScriptHonorTimeouts() async throws {
+        let bridge = JXABridge(timeout: 0.01)
+
+        do {
+            _ = try await bridge.execute("delay(0.2); 'done'")
+            Issue.record("Expected JXA timeout")
+        } catch let error as JXAError {
+            switch error {
+            case .timeout:
+                #expect(error.localizedDescription == "JXA script timed out")
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        do {
+            _ = try await bridge.executeAppleScript("delay 0.2\nreturn \"done\"")
+            Issue.record("Expected AppleScript timeout")
+        } catch let error as JXAError {
+            switch error {
+            case .timeout:
+                #expect(error.localizedDescription == "JXA script timed out")
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func executeAppleScriptAndRunningCheckUseSystemOsaScript() async throws {
+        let bridge = JXABridge(timeout: 1)
+        let appleScriptOutput = try await bridge.executeAppleScript("return \"hello from applescript\"")
+        #expect(appleScriptOutput == "hello from applescript")
+
+        let expectedOutput = try await bridge.execute("""
+        (() => {
+            const app = Application('Things3');
+            return app.running();
+        })()
+        """)
+        let isRunning = await bridge.isThingsRunning()
+
+        #expect(isRunning == (expectedOutput.lowercased() == "true"))
+    }
+}

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsClientTestSupport.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsClientTestSupport.swift
@@ -1,0 +1,170 @@
+// ThingsClientTestSupport.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+@testable import ClingsCore
+
+final class MockJXAExecutor: JXAExecuting, @unchecked Sendable {
+    enum StubError: Error {
+        case missingStub(String)
+    }
+
+    enum Stub {
+        case success(String)
+        case failure(Error)
+    }
+
+    private(set) var executeScripts: [String] = []
+    private(set) var executeJSONScripts: [String] = []
+    private(set) var appleScriptScripts: [String] = []
+
+    var executeResponses: [Stub] = []
+    var jsonResponses: [Stub] = []
+    var appleScriptResponses: [Stub] = []
+    var isThingsRunningValue = false
+
+    func execute(_ script: String) async throws -> String {
+        executeScripts.append(script)
+        return try popNext(from: &executeResponses, label: "execute")
+    }
+
+    func executeJSON<T: Decodable & Sendable>(_ script: String, as type: T.Type) async throws -> T {
+        executeJSONScripts.append(script)
+        let raw = try popNext(from: &jsonResponses, label: "executeJSON")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(T.self, from: Data(raw.utf8))
+    }
+
+    func executeAppleScript(_ script: String) async throws -> String {
+        appleScriptScripts.append(script)
+        return try popNext(from: &appleScriptResponses, label: "executeAppleScript")
+    }
+
+    func isThingsRunning() async -> Bool {
+        isThingsRunningValue
+    }
+
+    private func popNext(from responses: inout [Stub], label: String) throws -> String {
+        guard !responses.isEmpty else {
+            throw StubError.missingStub(label)
+        }
+
+        let response = responses.removeFirst()
+        switch response {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
+}
+
+final class MockThingsDatabaseReader: ThingsDatabaseReadable, @unchecked Sendable {
+    var lists: [ListView: [Todo]] = [:]
+    var projects: [Project] = []
+    var areas: [Area] = []
+    var tags: [Tag] = []
+    var todosByID: [String: Todo] = [:]
+    var searchResults: [Todo] = []
+    var error: Error?
+
+    private(set) var fetchedLists: [ListView] = []
+    private(set) var fetchedTodoIDs: [String] = []
+    private(set) var searchQueries: [String] = []
+
+    func fetchList(_ list: ListView) throws -> [Todo] {
+        if let error {
+            throw error
+        }
+        fetchedLists.append(list)
+        return lists[list] ?? []
+    }
+
+    func fetchProjects() throws -> [Project] {
+        if let error {
+            throw error
+        }
+        return projects
+    }
+
+    func fetchAreas() throws -> [Area] {
+        if let error {
+            throw error
+        }
+        return areas
+    }
+
+    func fetchTags() throws -> [Tag] {
+        if let error {
+            throw error
+        }
+        return tags
+    }
+
+    func fetchTodo(id: String) throws -> Todo {
+        if let error {
+            throw error
+        }
+        fetchedTodoIDs.append(id)
+        guard let todo = todosByID[id] else {
+            throw ThingsError.notFound(id)
+        }
+        return todo
+    }
+
+    func search(query: String) throws -> [Todo] {
+        if let error {
+            throw error
+        }
+        searchQueries.append(query)
+        return searchResults
+    }
+}
+
+func encodeJSON<T: Encodable>(_ value: T) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let data = try encoder.encode(value)
+    guard let string = String(data: data, encoding: .utf8) else {
+        throw NSError(domain: "ThingsClientTestSupport", code: 1)
+    }
+    return string
+}
+
+func jsonObjectString(_ object: [String: Any?]) throws -> String {
+    let sanitized = object.reduce(into: [String: Any]()) { partial, entry in
+        partial[entry.key] = entry.value ?? NSNull()
+    }
+    let data = try JSONSerialization.data(withJSONObject: sanitized, options: [.sortedKeys])
+    guard let string = String(data: data, encoding: .utf8) else {
+        throw NSError(domain: "ThingsClientTestSupport", code: 2)
+    }
+    return string
+}
+
+func mutationResultJSON(success: Bool, error: String? = nil, id: String? = nil) throws -> String {
+    try jsonObjectString([
+        "success": success,
+        "error": error,
+        "id": id,
+    ])
+}
+
+func creationResultJSON(success: Bool, error: String? = nil, id: String? = nil, name: String? = nil) throws -> String {
+    try jsonObjectString([
+        "success": success,
+        "error": error,
+        "id": id,
+        "name": name,
+    ])
+}
+
+func errorResponseJSON(error: String, id: String? = nil) throws -> String {
+    try jsonObjectString([
+        "error": error,
+        "id": id,
+    ])
+}

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsClientTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsClientTests.swift
@@ -1,0 +1,359 @@
+// ThingsClientTests.swift
+// clings - A powerful CLI for Things 3
+// Copyright (C) 2024 Dan Hart
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import Foundation
+import Testing
+@testable import ClingsCore
+
+@Suite("ThingsClient")
+struct ThingsClientTests {
+    @Test func fetchCollectionMethodsDecodeJSONResponses() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.jsonResponses = [
+            .success(try encodeJSON([TestData.todoOpen])),
+            .success(try encodeJSON([TestData.projectAlpha])),
+            .success(try encodeJSON([TestData.workArea])),
+            .success(try encodeJSON([TestData.workTag])),
+            .success(try encodeJSON([TestData.todoNoProject])),
+        ]
+
+        let client = ThingsClient(bridge: bridge)
+
+        let today = try await client.fetchList(.today)
+        let projects = try await client.fetchProjects()
+        let areas = try await client.fetchAreas()
+        let tags = try await client.fetchTags()
+        let searchResults = try await client.search(query: "home")
+
+        #expect(today == [TestData.todoOpen])
+        #expect(projects.count == 1)
+        #expect(projects[0].id == TestData.projectAlpha.id)
+        #expect(projects[0].name == TestData.projectAlpha.name)
+        #expect(areas == [TestData.workArea])
+        #expect(tags == [TestData.workTag])
+        #expect(searchResults == [TestData.todoNoProject])
+        #expect(bridge.executeJSONScripts.count == 5)
+        #expect(bridge.executeJSONScripts[0].contains("toDos"))
+        #expect(bridge.executeJSONScripts[4].contains("home"))
+    }
+
+    @Test func fetchCollectionMethodsWrapBridgeErrors() async {
+        let bridge = MockJXAExecutor()
+        bridge.jsonResponses = [
+            .failure(JXAError.thingsNotRunning),
+            .failure(JXAError.scriptError("projects")),
+            .failure(JXAError.scriptError("areas")),
+            .failure(JXAError.scriptError("tags")),
+            .failure(JXAError.scriptError("search")),
+        ]
+
+        let client = ThingsClient(bridge: bridge)
+
+        await expectJXAError(from: { _ = try await client.fetchList(.today) }, contains: "Things 3 is not running")
+        await expectJXAError(from: { _ = try await client.fetchProjects() }, contains: "projects")
+        await expectJXAError(from: { _ = try await client.fetchAreas() }, contains: "areas")
+        await expectJXAError(from: { _ = try await client.fetchTags() }, contains: "tags")
+        await expectJXAError(from: { _ = try await client.search(query: "q") }, contains: "search")
+    }
+
+    @Test func fetchTodoHandlesSuccessNotFoundAndDecodeFailures() async throws {
+        let validBridge = MockJXAExecutor()
+        validBridge.executeResponses = [.success(try encodeJSON(TestData.todoOpen))]
+
+        let validClient = ThingsClient(bridge: validBridge)
+        let todo = try await validClient.fetchTodo(id: TestData.todoOpen.id)
+        #expect(todo == TestData.todoOpen)
+
+        let notFoundBridge = MockJXAExecutor()
+        notFoundBridge.executeResponses = [.success(try errorResponseJSON(error: "missing", id: TestData.todoOpen.id))]
+
+        let notFoundClient = ThingsClient(bridge: notFoundBridge)
+        do {
+            _ = try await notFoundClient.fetchTodo(id: TestData.todoOpen.id)
+            Issue.record("Expected notFound error")
+        } catch let error as ThingsError {
+            switch error {
+            case .notFound(let id):
+                #expect(id == TestData.todoOpen.id)
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let invalidBridge = MockJXAExecutor()
+        invalidBridge.executeResponses = [.success("{\"id\":\"broken\"}")]
+
+        let invalidClient = ThingsClient(bridge: invalidBridge)
+        do {
+            _ = try await invalidClient.fetchTodo(id: "broken")
+            Issue.record("Expected decode failure")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message.contains("Failed to decode todo"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func createTodoUsesAppleScriptAppliesTagsAndRequiresCreatedID() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.appleScriptResponses = [
+            .success("todo-created-id"),
+            .success("ok"),
+        ]
+
+        let client = ThingsClient(bridge: bridge)
+        let createdID = try await client.createTodo(
+            name: "Ship docs",
+            notes: "Publish examples",
+            when: Date(timeIntervalSinceReferenceDate: 10),
+            deadline: Date(timeIntervalSinceReferenceDate: 20),
+            tags: ["docs", "release"],
+            project: "Project Alpha",
+            area: "Work",
+            checklistItems: ["Draft", "Review"]
+        )
+
+        #expect(createdID == "todo-created-id")
+        #expect(bridge.appleScriptScripts.count == 2)
+        #expect(bridge.appleScriptScripts[0].contains("Ship docs"))
+        #expect(bridge.appleScriptScripts[0].contains("Draft"))
+        #expect(bridge.appleScriptScripts[1].contains("release"))
+
+        let missingIDBridge = MockJXAExecutor()
+        missingIDBridge.appleScriptResponses = [.success("")]
+        let missingIDClient = ThingsClient(bridge: missingIDBridge)
+
+        do {
+            _ = try await missingIDClient.createTodo(
+                name: "Broken",
+                notes: nil,
+                when: nil,
+                deadline: nil,
+                tags: [],
+                project: nil,
+                area: nil,
+                checklistItems: []
+            )
+            Issue.record("Expected missing ID error")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message.contains("Missing created todo ID"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        let tagFailureBridge = MockJXAExecutor()
+        tagFailureBridge.appleScriptResponses = [
+            .success("todo-created-id"),
+            .failure(JXAError.scriptError("tag failure")),
+        ]
+        let tagFailureClient = ThingsClient(bridge: tagFailureBridge)
+        await expectJXAError(
+            from: {
+                _ = try await tagFailureClient.createTodo(
+                    name: "Needs tags",
+                    notes: nil,
+                    when: nil,
+                    deadline: nil,
+                    tags: ["docs"],
+                    project: nil,
+                    area: nil,
+                    checklistItems: []
+                )
+            },
+            contains: "tag failure"
+        )
+    }
+
+    @Test func createProjectHandlesJSONResponsesAndTagUpdates() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.jsonResponses = [.success(try creationResultJSON(success: true, id: "project-id", name: "Ops"))]
+        bridge.appleScriptResponses = [.success("ok")]
+
+        let client = ThingsClient(bridge: bridge)
+        let createdID = try await client.createProject(
+            name: "Ops",
+            notes: "Runbook",
+            when: Date(timeIntervalSinceReferenceDate: 30),
+            deadline: Date(timeIntervalSinceReferenceDate: 40),
+            tags: ["ops"],
+            area: "Work"
+        )
+
+        #expect(createdID == "project-id")
+        #expect(bridge.executeJSONScripts.count == 1)
+        #expect(bridge.appleScriptScripts.count == 1)
+        #expect(bridge.appleScriptScripts[0].contains("ops"))
+
+        let failingBridge = MockJXAExecutor()
+        failingBridge.jsonResponses = [.success(try creationResultJSON(success: false, error: "project failed"))]
+        let failingClient = ThingsClient(bridge: failingBridge)
+        do {
+            _ = try await failingClient.createProject(
+                name: "Broken",
+                notes: nil,
+                when: nil,
+                deadline: nil,
+                tags: [],
+                area: nil
+            )
+            Issue.record("Expected createProject failure")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message == "project failed")
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func mutationMethodsAndUpdateTodoHandleSuccessAndFailurePaths() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.jsonResponses = [
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+            .success(try mutationResultJSON(success: true)),
+        ]
+        bridge.appleScriptResponses = [
+            .success("ok"),
+            .success("ok"),
+        ]
+
+        let client = ThingsClient(bridge: bridge)
+        try await client.completeTodo(id: "todo-1")
+        try await client.reopenTodo(id: "todo-1")
+        try await client.cancelTodo(id: "todo-1")
+        try await client.deleteTodo(id: "todo-1")
+        try await client.moveTodo(id: "todo-1", toProject: "Ops")
+        try await client.updateTodo(
+            id: "todo-1",
+            name: "Renamed",
+            notes: "Updated",
+            dueDate: Date(timeIntervalSinceReferenceDate: 50),
+            tags: ["ops"]
+        )
+        try await client.updateTodo(
+            id: "todo-1",
+            name: nil,
+            notes: nil,
+            dueDate: nil,
+            tags: ["solo-tag"]
+        )
+
+        #expect(bridge.executeJSONScripts.count == 6)
+        #expect(bridge.appleScriptScripts.count == 2)
+        #expect(bridge.executeJSONScripts[4].contains("Ops"))
+        #expect(bridge.executeJSONScripts[5].contains("Renamed"))
+        #expect(bridge.appleScriptScripts[1].contains("solo-tag"))
+
+        let failureBridge = MockJXAExecutor()
+        failureBridge.jsonResponses = [.success(try mutationResultJSON(success: false, error: "mutation failed"))]
+        let failureClient = ThingsClient(bridge: failureBridge)
+
+        do {
+            try await failureClient.completeTodo(id: "todo-2")
+            Issue.record("Expected mutation failure")
+        } catch let error as ThingsError {
+            switch error {
+            case .operationFailed(let message):
+                #expect(message == "mutation failed")
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test func tagManagementMethodsWrapJXAErrors() async throws {
+        let bridge = MockJXAExecutor()
+        bridge.appleScriptResponses = [
+            .success("tag-id"),
+            .success(""),
+            .success(""),
+        ]
+
+        let client = ThingsClient(bridge: bridge)
+        let tag = try await client.createTag(name: "docs")
+        try await client.deleteTag(name: "docs")
+        try await client.renameTag(oldName: "docs", newName: "guides")
+
+        #expect(tag == Tag(id: "tag-id", name: "docs"))
+        #expect(bridge.appleScriptScripts.count == 3)
+
+        let failingBridge = MockJXAExecutor()
+        failingBridge.appleScriptResponses = [.failure(JXAError.scriptError("delete failed"))]
+        let failingClient = ThingsClient(bridge: failingBridge)
+        await expectJXAError(from: { try await failingClient.deleteTag(name: "docs") }, contains: "delete failed")
+    }
+
+    @Test func openCommandsAreDisabled() {
+        let client = ThingsClient(bridge: MockJXAExecutor())
+
+        do {
+            try client.openInThings(id: "todo-1")
+            Issue.record("Expected openInThings(id:) to throw")
+        } catch let error as ThingsError {
+            switch error {
+            case .invalidState(let message):
+                #expect(message.contains("Open command is disabled"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        do {
+            try client.openInThings(list: .today)
+            Issue.record("Expected openInThings(list:) to throw")
+        } catch let error as ThingsError {
+            switch error {
+            case .invalidState(let message):
+                #expect(message.contains("Open command is disabled"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    private func expectJXAError(
+        from operation: () async throws -> Void,
+        contains fragment: String
+    ) async {
+        do {
+            try await operation()
+            Issue.record("Expected JXA-backed ThingsError")
+        } catch let error as ThingsError {
+            switch error {
+            case .jxaError(let jxaError):
+                #expect(jxaError.localizedDescription.contains(fragment))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
@@ -93,15 +93,141 @@ struct ThingsDatabaseTests {
         #expect(todoIDs == ["open-today"])
     }
 
+    @Test func fetchProjectsIncludesAreaTagsAndDates() throws {
+        let fixture = try makeFixtureDatabase()
+        let deadline = 1_234
+        let createdAt = 4_567.0
+
+        try fixture.db.write { db in
+            try insertArea(db, id: "area-work", title: "Work", index: 0)
+            try insertTag(db, id: "tag-docs", title: "docs")
+            try insertTask(
+                db,
+                id: "project-1",
+                title: "Documentation",
+                start: 0,
+                startDate: nil,
+                index: 0,
+                type: 1,
+                notes: "Project notes",
+                deadline: deadline,
+                creationDate: createdAt,
+                area: "area-work"
+            )
+            try insertTaskTag(db, taskID: "project-1", tagID: "tag-docs")
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let projects = try database.fetchProjects()
+
+        #expect(projects.count == 1)
+        #expect(projects[0].id == "project-1")
+        #expect(projects[0].name == "Documentation")
+        #expect(projects[0].notes == "Project notes")
+        #expect(projects[0].area?.name == "Work")
+        #expect(projects[0].tags.map(\.name) == ["docs"])
+        #expect(projects[0].dueDate == Date(timeIntervalSinceReferenceDate: TimeInterval(deadline)))
+        #expect(projects[0].creationDate == Date(timeIntervalSinceReferenceDate: TimeInterval(createdAt)))
+    }
+
+    @Test func fetchAreasAndTagsReturnAttachedMetadata() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertArea(db, id: "area-home", title: "Home", index: 0)
+            try insertTag(db, id: "tag-home", title: "home")
+            try insertTag(db, id: "tag-errands", title: "errands")
+            try db.execute(
+                sql: "INSERT INTO TMAreaTag (areas, tags) VALUES (?, ?), (?, ?)",
+                arguments: ["area-home", "tag-home", "area-home", "tag-errands"]
+            )
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let areas = try database.fetchAreas()
+        let tags = try database.fetchTags()
+
+        #expect(areas.count == 1)
+        #expect(areas[0].name == "Home")
+        #expect(areas[0].tags.map(\.name).sorted() == ["errands", "home"])
+        #expect(tags.map(\.name) == ["errands", "home"])
+    }
+
+    @Test func fetchTodoAndSearchReturnRichTodoMetadata() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertArea(db, id: "area-work", title: "Work", index: 0)
+            try insertTag(db, id: "tag-docs", title: "docs")
+            try insertTask(
+                db,
+                id: "project-1",
+                title: "Documentation",
+                start: 0,
+                startDate: nil,
+                index: 0,
+                type: 1
+            )
+            try insertTask(
+                db,
+                id: "todo-1",
+                title: "Ship docs",
+                start: 1,
+                startDate: thingsDateCode(Date()),
+                index: 1,
+                notes: "Coordinate release notes",
+                deadline: 900,
+                creationDate: 100,
+                modificationDate: 200,
+                project: "project-1",
+                area: "area-work"
+            )
+            try insertTaskTag(db, taskID: "todo-1", tagID: "tag-docs")
+            try db.execute(
+                sql: """
+                    INSERT INTO TMChecklistItem (uuid, title, status, task, "index")
+                    VALUES
+                        ('check-1', 'Draft outline', 3, 'todo-1', 0),
+                        ('check-2', 'Publish examples', 0, 'todo-1', 1)
+                    """
+            )
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let todo = try database.fetchTodo(id: "todo-1")
+        let searchResults = try database.search(query: "release")
+
+        #expect(todo.name == "Ship docs")
+        #expect(todo.notes == "Coordinate release notes")
+        #expect(todo.project?.name == "Documentation")
+        #expect(todo.area?.name == "Work")
+        #expect(todo.tags.map(\.name) == ["docs"])
+        #expect(todo.checklistItems.map(\.name) == ["Draft outline", "Publish examples"])
+        #expect(todo.checklistItems.map(\.completed) == [true, false])
+        #expect(todo.dueDate == Date(timeIntervalSinceReferenceDate: 900))
+        #expect(todo.creationDate == Date(timeIntervalSinceReferenceDate: 100))
+        #expect(todo.modificationDate == Date(timeIntervalSinceReferenceDate: 200))
+        #expect(searchResults.map(\.id) == ["todo-1"])
+    }
+
+    @Test func fetchTodoThrowsNotFoundForUnknownID() throws {
+        let fixture = try makeFixtureDatabase()
+        let database = ThingsDatabase(dbPath: fixture.path)
+
+        #expect(throws: ThingsError.self) {
+            _ = try database.fetchTodo(id: "missing")
+        }
+    }
+
     private func makeFixtureDatabase() throws -> (path: String, db: DatabaseQueue) {
         let tempURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("clings-thingsdb-tests-\(UUID().uuidString).sqlite")
         let dbQueue = try DatabaseQueue(path: tempURL.path)
 
-        try dbQueue.write { db in
-            try db.execute(
-                sql: """
-                    CREATE TABLE TMTask (
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        CREATE TABLE TMTask (
                         uuid TEXT PRIMARY KEY,
                         title TEXT NOT NULL,
                         notes TEXT,
@@ -118,13 +244,22 @@ struct ThingsDatabaseTests {
                         startDate INTEGER,
                         todayIndex INTEGER,
                         "index" INTEGER NOT NULL
+                        )
+                        """
+                )
+
+            try db.execute(
+                sql: """
+                    CREATE TABLE TMArea (
+                        uuid TEXT PRIMARY KEY,
+                        title TEXT NOT NULL,
+                        "index" INTEGER NOT NULL DEFAULT 0
                     )
                     """
             )
-
-            try db.execute(sql: "CREATE TABLE TMArea (uuid TEXT PRIMARY KEY, title TEXT NOT NULL)")
             try db.execute(sql: "CREATE TABLE TMTag (uuid TEXT PRIMARY KEY, title TEXT NOT NULL)")
             try db.execute(sql: "CREATE TABLE TMTaskTag (tasks TEXT NOT NULL, tags TEXT NOT NULL)")
+            try db.execute(sql: "CREATE TABLE TMAreaTag (areas TEXT NOT NULL, tags TEXT NOT NULL)")
             try db.execute(
                 sql: """
                     CREATE TABLE TMChecklistItem (
@@ -149,16 +284,59 @@ struct ThingsDatabaseTests {
         startDate: Int?,
         index: Int,
         status: Int = 0,
-        trashed: Int = 0
+        trashed: Int = 0,
+        type: Int = 0,
+        notes: String? = nil,
+        deadline: Int? = nil,
+        creationDate: Double = 0,
+        modificationDate: Double? = nil,
+        project: String? = nil,
+        area: String? = nil
     ) throws {
         try db.execute(
             sql: """
                 INSERT INTO TMTask (
                     uuid, title, notes, status, stopDate, deadline, creationDate, userModificationDate,
                     project, area, trashed, type, start, startDate, todayIndex, "index"
-                ) VALUES (?, ?, NULL, ?, NULL, NULL, 0, 0, NULL, NULL, ?, 0, ?, ?, 0, ?)
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
                 """,
-            arguments: [id, title, status, trashed, start, startDate, index]
+            arguments: [
+                id,
+                title,
+                notes,
+                status,
+                deadline,
+                creationDate,
+                modificationDate ?? creationDate,
+                project,
+                area,
+                trashed,
+                type,
+                start,
+                startDate,
+                index,
+            ]
+        )
+    }
+
+    private func insertArea(_ db: Database, id: String, title: String, index: Int) throws {
+        try db.execute(
+            sql: "INSERT INTO TMArea (uuid, title, \"index\") VALUES (?, ?, ?)",
+            arguments: [id, title, index]
+        )
+    }
+
+    private func insertTag(_ db: Database, id: String, title: String) throws {
+        try db.execute(
+            sql: "INSERT INTO TMTag (uuid, title) VALUES (?, ?)",
+            arguments: [id, title]
+        )
+    }
+
+    private func insertTaskTag(_ db: Database, taskID: String, tagID: String) throws {
+        try db.execute(
+            sql: "INSERT INTO TMTaskTag (tasks, tags) VALUES (?, ?)",
+            arguments: [taskID, tagID]
         )
     }
 

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -20,8 +20,8 @@ Quick examples:
 
 ```bash
 clings today
-clings add "Review release checklist tomorrow #docs"
-clings views run work-today
+clings add "Draft changelog entry tomorrow #docs"
+clings views run docs-today
 clings doctor --verbose
 ```
 
@@ -55,12 +55,12 @@ clings <command> <subcommand> --help
 Use `add` when you want fast capture, `search` when you want free-text lookup, and `filter` when you want structured querying.
 
 ```bash
-clings add "Publish release notes tomorrow #docs"
+clings add "Draft changelog entry tomorrow #docs"
 clings add "Weekly review prep" --template weekly-review
 clings add "Test task tomorrow #docs" --parse-only --json
 
 clings search "release"
-clings filter "area = 'Work' AND due <= today"
+clings filter "tags CONTAINS 'docs' AND due <= today"
 clings today --format "{status} {name} [{project}]"
 ```
 
@@ -109,7 +109,7 @@ clings pick delete cleanup
 
 ```bash
 clings project list
-clings project add "Release Readiness" --area "Operations" --deadline 2025-06-01
+clings project add "Writing Sprint" --area "Writing" --deadline 2025-06-01
 clings project audit
 clings project audit --json
 
@@ -125,8 +125,8 @@ Preview first with `--dry-run`, then repeat the same command without it when the
 ```bash
 clings bulk complete --where "tags CONTAINS 'done'" --dry-run
 clings bulk complete --where "tags CONTAINS 'done'"
-clings bulk cancel --where "project = 'Old Project'"
-clings bulk tag "urgent,priority" --where "area = 'Work'"
+clings bulk cancel --where "project = 'Archive Prep'"
+clings bulk tag "urgent,priority" --where "tags CONTAINS 'docs'"
 clings bulk move --where "tags CONTAINS 'docs'" --to "Documentation"
 ```
 

--- a/docs/cli/command-reference.md
+++ b/docs/cli/command-reference.md
@@ -1,0 +1,160 @@
+# clings Command Reference
+
+This guide mirrors the built-in help text and gives quick examples for the main `clings` command families.
+
+For the latest option-level details, run:
+
+```bash
+clings --help
+clings <command> --help
+clings <command> <subcommand> --help
+```
+
+## Root Usage
+
+```bash
+clings <subcommand> [options]
+```
+
+Quick examples:
+
+```bash
+clings today
+clings add "Review release checklist tomorrow #docs"
+clings views run work-today
+clings doctor --verbose
+```
+
+## Help Usage
+
+Built-in help is organized around the same command families documented here:
+
+```bash
+clings --help
+clings <command> --help
+clings <command> <subcommand> --help
+```
+
+## Core Lists
+
+| Command | Purpose | Example |
+| --- | --- | --- |
+| `clings today` | Show tasks scheduled for today | `clings today --format "{status} {name}"` |
+| `clings inbox` | Show inbox items | `clings inbox --json` |
+| `clings upcoming` | Show future scheduled work | `clings upcoming` |
+| `clings anytime` | Show unscheduled anytime work | `clings anytime --json` |
+| `clings someday` | Show someday/maybe items | `clings someday` |
+| `clings logbook` | Show completed tasks | `clings logbook --json` |
+| `clings projects` | List projects | `clings projects --json` |
+| `clings areas` | List areas | `clings areas` |
+| `clings tags list` | List tags | `clings tags ls --json` |
+| `clings show <id>` | Show one todo in detail | `clings show abc123 --json` |
+
+## Capture, Search, and Reuse
+
+Use `add` when you want fast capture, `search` when you want free-text lookup, and `filter` when you want structured querying.
+
+```bash
+clings add "Publish release notes tomorrow #docs"
+clings add "Weekly review prep" --template weekly-review
+clings add "Test task tomorrow #docs" --parse-only --json
+
+clings search "release"
+clings filter "area = 'Work' AND due <= today"
+clings today --format "{status} {name} [{project}]"
+```
+
+Saved views help you keep favorite filters close at hand:
+
+```bash
+clings views save docs "tags CONTAINS 'docs'" --note "Documentation queue"
+clings views list
+clings views run docs
+clings views delete docs
+```
+
+Templates help you reuse repeated task shapes:
+
+```bash
+clings template save weekly-review "Weekly review" --when "tomorrow morning"
+clings template list
+clings template run weekly-review
+clings template delete weekly-review
+```
+
+## Mutations and Interactive Picking
+
+Use direct mutation commands when you already know the ID or title target:
+
+```bash
+clings complete abc123
+clings complete --title "Review release checklist"
+clings cancel abc123
+clings delete abc123 --force
+clings update abc123 --name "Updated title" --tags docs urgent
+clings undo
+clings undo --show
+```
+
+Use `pick` when you want an interactive chooser instead of copying IDs:
+
+```bash
+clings pick show release
+clings pick complete docs
+clings pick cancel follow-up
+clings pick delete cleanup
+```
+
+## Project and Tag Management
+
+```bash
+clings project list
+clings project add "Release Readiness" --area "Operations" --deadline 2025-06-01
+clings project audit
+clings project audit --json
+
+clings tags add "docs"
+clings tags rename "docs" "guides"
+clings tags delete "guides" --force
+```
+
+## Bulk Workflows
+
+Preview first with `--dry-run`, then repeat the same command without it when the selection looks right.
+
+```bash
+clings bulk complete --where "tags CONTAINS 'done'" --dry-run
+clings bulk complete --where "tags CONTAINS 'done'"
+clings bulk cancel --where "project = 'Old Project'"
+clings bulk tag "urgent,priority" --where "area = 'Work'"
+clings bulk move --where "tags CONTAINS 'docs'" --to "Documentation"
+```
+
+## Review, Focus, and Reporting
+
+```bash
+clings focus
+clings focus --limit 5
+clings focus --format "{status} {name} [{project}]"
+
+clings review
+clings review status
+clings review clear
+
+clings stats
+clings stats --days 7
+clings stats trends
+clings stats heatmap
+```
+
+## Environment and Utilities
+
+```bash
+clings doctor
+clings doctor --verbose
+clings config set-auth-token <token>
+clings completions zsh > ~/.zfunc/_clings
+clings open today
+```
+
+`open` is intentionally disabled in the current CLI build, so use it only if that behavior changes in a future release.

--- a/docs/development/testing-and-coverage.md
+++ b/docs/development/testing-and-coverage.md
@@ -1,0 +1,72 @@
+# Testing and Coverage
+
+`clings` uses Swift Testing for the package test suite, and the project target is at least 80% source coverage.
+
+## Everyday Verification
+
+Run the regular test suite:
+
+```bash
+swift test
+```
+
+Build the CLI:
+
+```bash
+swift build
+swift build -c release
+```
+
+## Coverage Workflow
+
+Generate coverage artifacts:
+
+```bash
+swift test --enable-code-coverage
+```
+
+The project measures coverage against files in `Sources/`, not bundled dependencies. This command reports the source-only total:
+
+```bash
+xcrun llvm-cov export -summary-only \
+  .build/arm64-apple-macosx/debug/clingsPackageTests.xctest/Contents/MacOS/clingsPackageTests \
+  -instr-profile=.build/arm64-apple-macosx/debug/codecov/default.profdata |
+  jq --arg sourcesPrefix "$(pwd)/Sources/" \
+     '[.data[0].files[] | select(.filename | startswith($sourcesPrefix))] |
+      {files: length,
+       lines_total: (map(.summary.lines.count) | add),
+       lines_covered: (map(.summary.lines.covered) | add),
+       line_percent: ((map(.summary.lines.covered) | add) / (map(.summary.lines.count) | add) * 100)}'
+```
+
+## File-Level Drilldown
+
+Use this report to spot low-coverage files inside `Sources/`:
+
+```bash
+xcrun llvm-cov export -summary-only \
+  .build/arm64-apple-macosx/debug/clingsPackageTests.xctest/Contents/MacOS/clingsPackageTests \
+  -instr-profile=.build/arm64-apple-macosx/debug/codecov/default.profdata |
+  jq -r --arg sourcesPrefix "$(pwd)/Sources/" '.data[0].files[] |
+         select(.filename | startswith($sourcesPrefix)) |
+         [.summary.lines.percent, .summary.lines.count, .summary.lines.covered, .filename] |
+         @tsv' |
+  sort -n
+```
+
+## Suggested Release Preflight
+
+Before cutting a release:
+
+```bash
+swift test
+swift test --enable-code-coverage
+swift build
+swift build -c release
+bash scripts/release-docs-check.sh
+```
+
+## Notes
+
+- Prefer source-only coverage when discussing the project target. Dependency coverage from `swift-argument-parser`, GRDB, and SwiftDate will otherwise dilute the total.
+- Keep command help and `docs/` aligned. If you add a new command family, update the command reference and rerun the docs check script.

--- a/docs/release/help-readme-docs-checklist.md
+++ b/docs/release/help-readme-docs-checklist.md
@@ -30,6 +30,6 @@ swift run clings bulk move --help
 
 - Update `CHANGELOG.md` under `Unreleased`
 - Confirm README command reference matches current CLI
-- Confirm [docs/cli/command-reference.md](/Users/danhart/Developer/clings/docs/cli/command-reference.md) reflects the current help text and examples
-- Confirm [docs/development/testing-and-coverage.md](/Users/danhart/Developer/clings/docs/development/testing-and-coverage.md) still matches the supported verification workflow
+- Confirm [docs/cli/command-reference.md](../cli/command-reference.md) reflects the current help text and examples
+- Confirm [docs/development/testing-and-coverage.md](../development/testing-and-coverage.md) still matches the supported verification workflow
 - Confirm issue-specific docs are linked for important behavior changes

--- a/docs/release/help-readme-docs-checklist.md
+++ b/docs/release/help-readme-docs-checklist.md
@@ -30,4 +30,6 @@ swift run clings bulk move --help
 
 - Update `CHANGELOG.md` under `Unreleased`
 - Confirm README command reference matches current CLI
+- Confirm [docs/cli/command-reference.md](/Users/danhart/Developer/clings/docs/cli/command-reference.md) reflects the current help text and examples
+- Confirm [docs/development/testing-and-coverage.md](/Users/danhart/Developer/clings/docs/development/testing-and-coverage.md) still matches the supported verification workflow
 - Confirm issue-specific docs are linked for important behavior changes

--- a/docs/superpowers/plans/2026-03-30-clings-productivity-suite.md
+++ b/docs/superpowers/plans/2026-03-30-clings-productivity-suite.md
@@ -1,6 +1,6 @@
 # Clings Productivity Suite Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> This plan records the implementation checklist used to ship the productivity-suite work. The checkbox format is kept for traceability.
 
 **Goal:** Add 10 shippable CLI improvements to `clings` with shared local state, better analysis, and stronger task capture.
 

--- a/docs/superpowers/plans/2026-03-30-clings-productivity-suite.md
+++ b/docs/superpowers/plans/2026-03-30-clings-productivity-suite.md
@@ -1,0 +1,118 @@
+# Clings Productivity Suite Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 10 shippable CLI improvements to `clings` with shared local state, better analysis, and stronger task capture.
+
+**Architecture:** Add a focused config/state layer in `ClingsCore`, then build command-facing analyzers and helpers on top of it. Keep command implementations thin by pushing persistence, formatting, focus scoring, review summaries, and project audit logic into reusable core types.
+
+**Tech Stack:** Swift 6, ArgumentParser, GRDB, Foundation, Swift Testing
+
+---
+
+### Task 1: Add shared config/state storage
+
+**Files:**
+- Create: `Sources/ClingsCore/Config/ClingsConfig.swift`
+- Create: `Sources/ClingsCore/Config/JSONFileStore.swift`
+- Modify: `Sources/ClingsCore/Config/AuthTokenStore.swift`
+- Test: `Tests/ClingsCoreTests/Config/JSONFileStoreTests.swift`
+
+- [ ] Write failing tests for config directory resolution and JSON round-trips
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement shared config helpers and migrate auth token path lookup
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 2: Add reusable local feature stores
+
+**Files:**
+- Create: `Sources/ClingsCore/Config/SavedViewStore.swift`
+- Create: `Sources/ClingsCore/Config/TemplateStore.swift`
+- Create: `Sources/ClingsCore/Config/UndoStore.swift`
+- Test: `Tests/ClingsCoreTests/Config/SavedViewStoreTests.swift`
+- Test: `Tests/ClingsCoreTests/Config/TemplateStoreTests.swift`
+- Test: `Tests/ClingsCoreTests/Config/UndoStoreTests.swift`
+
+- [ ] Write failing storage tests for views, templates, and undo history
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement codable stores and trimming/replace semantics
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 3: Add analyzers for review, audit, and focus
+
+**Files:**
+- Create: `Sources/ClingsCore/Analysis/ProjectAudit.swift`
+- Create: `Sources/ClingsCore/Analysis/FocusPlanner.swift`
+- Create: `Sources/ClingsCore/Analysis/ReviewAssistant.swift`
+- Test: `Tests/ClingsCoreTests/Analysis/ProjectAuditTests.swift`
+- Test: `Tests/ClingsCoreTests/Analysis/FocusPlannerTests.swift`
+- Test: `Tests/ClingsCoreTests/Analysis/ReviewAssistantTests.swift`
+
+- [ ] Write failing tests for health findings, focus ranking, and review summary heuristics
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement analyzers
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 4: Strengthen natural-language parsing and todo formatting
+
+**Files:**
+- Create: `Sources/ClingsCore/NLP/NaturalLanguageDateParser.swift`
+- Create: `Sources/ClingsCore/Output/TodoLineFormatter.swift`
+- Modify: `Sources/ClingsCore/NLP/TaskParser.swift`
+- Modify: `Sources/ClingsCore/Output/OutputFormatter.swift`
+- Test: `Tests/ClingsCoreTests/NLP/NaturalLanguageDateParserTests.swift`
+- Test: `Tests/ClingsCoreTests/NLP/TaskParserTests.swift`
+- Test: `Tests/ClingsCoreTests/Output/TodoLineFormatterTests.swift`
+
+- [ ] Write failing tests for new date phrases, quoted project/area parsing, and custom line formats
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement parser and formatter support
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 5: Expand command surface
+
+**Files:**
+- Create: `Sources/ClingsCLI/Commands/DoctorCommand.swift`
+- Create: `Sources/ClingsCLI/Commands/ViewsCommand.swift`
+- Create: `Sources/ClingsCLI/Commands/TemplateCommand.swift`
+- Create: `Sources/ClingsCLI/Commands/UndoCommand.swift`
+- Create: `Sources/ClingsCLI/Commands/FocusCommand.swift`
+- Create: `Sources/ClingsCLI/Commands/PickCommand.swift`
+- Create: `Sources/ClingsCLI/Support/CommandSupport.swift`
+- Modify: `Sources/ClingsCLI/Clings.swift`
+- Test: `Tests/ClingsCLITests/ArgumentParsingTests.swift`
+- Test: `Tests/ClingsCLITests/CommandConfigurationTests.swift`
+
+- [ ] Write failing argument/configuration tests for the new commands
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement commands and shared CLI helpers
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 6: Upgrade existing commands
+
+**Files:**
+- Modify: `Sources/ClingsCLI/Commands/AddCommand.swift`
+- Modify: `Sources/ClingsCLI/Commands/ListCommands.swift`
+- Modify: `Sources/ClingsCLI/Commands/SearchCommand.swift`
+- Modify: `Sources/ClingsCLI/Commands/FilterCommand.swift`
+- Modify: `Sources/ClingsCLI/Commands/MutationCommands.swift`
+- Modify: `Sources/ClingsCLI/Commands/ProjectCommands.swift`
+- Modify: `Sources/ClingsCLI/Commands/ReviewCommand.swift`
+- Test: `Tests/ClingsCLITests/ArgumentParsingTests.swift`
+
+- [ ] Write failing parsing/behavior-oriented tests for template use, custom formatting, undo recording support, audit routing, and improved review options
+- [ ] Run targeted tests and confirm failures
+- [ ] Implement command changes with minimal code paths
+- [ ] Re-run targeted tests and confirm passes
+
+### Task 7: Update docs and verify end-to-end
+
+**Files:**
+- Modify: `README.md`
+- Verify: `swift test`
+- Verify: `swift build`
+
+- [ ] Update README command documentation for new features
+- [ ] Run the full test suite
+- [ ] Run a full build
+- [ ] Fix any regressions and re-run verification

--- a/docs/superpowers/specs/2026-03-30-clings-productivity-suite-design.md
+++ b/docs/superpowers/specs/2026-03-30-clings-productivity-suite-design.md
@@ -1,0 +1,24 @@
+# Clings Productivity Suite Design
+
+**Goal:** Ship 10 practical CLI improvements for `clings` in one cohesive pass without changing its core hybrid read/write architecture.
+
+**Approach:** Keep reads on SQLite and writes on JXA/AppleScript, but add a small state layer under `~/.config/clings` for reusable local features: saved views, templates, undo history, and richer review state. Prefer thin, composable commands over large interactive subsystems.
+
+**Scope:**
+- `doctor` command for setup diagnostics
+- saved filter views via `views`
+- interactive pick flows via `pick`
+- `undo` for supported recent mutations
+- smarter `review`
+- project health auditing via `project audit`
+- task templates via `template` and `add --template`
+- stronger natural-language date capture
+- custom line formatting for todo-list style commands
+- new `focus` command for a daily working view
+
+**Best-guess product decisions:**
+- Persist local command state in JSON files under the existing config directory.
+- Make undo explicitly limited to supported actions instead of pretending to be universal.
+- Implement pick mode as a dedicated `pick` command to avoid invasive argument changes across many existing commands.
+- Keep template scheduling expressions relative by storing raw strings like `tomorrow` instead of freezing parsed dates.
+- Reuse shared analyzers for review, focus, and project audit so the heuristics stay consistent.

--- a/scripts/release-docs-check.sh
+++ b/scripts/release-docs-check.sh
@@ -55,9 +55,20 @@ if [[ "${#missing_in_completions[@]}" -gt 0 ]]; then
   fail "zsh completions missing commands: ${missing_in_completions[*]}"
 fi
 
-PERSONAL_PATTERN='(Call mom|Buy milk|ProjectName|Q1 Planning|Sprint 12|Family)'
-if rg -n "$PERSONAL_PATTERN" Sources/ClingsCLI/Clings.swift Sources/ClingsCLI/Commands README.md -S >/dev/null; then
-  fail "found personal or placeholder examples in help/docs (update examples to neutral text)"
+PUBLIC_DOC_FILES=(
+  README.md
+  Sources/ClingsCLI/Clings.swift
+  Sources/ClingsCLI/Commands
+  docs
+)
+
+PERSONAL_PATTERN='(Call mom|Buy milk|ProjectName|Q1 Planning|Sprint 12|Family|expense report|Migration Project|Operations Project)'
+if rg -n "$PERSONAL_PATTERN" "${PUBLIC_DOC_FILES[@]}" -S >/dev/null; then
+  fail "found personal, work-specific, or placeholder examples in help/docs (update examples to neutral text)"
+fi
+
+if rg -n '/Users/' "${PUBLIC_DOC_FILES[@]}" -S >/dev/null; then
+  fail "found absolute local filesystem paths in public docs/help"
 fi
 
 echo "release-docs-check: OK"


### PR DESCRIPTION
## Summary
- add the new productivity workflow command families: `views`, `template`, `undo`, `focus`, `pick`, `doctor`, and `project audit`
- add config-backed local state, richer Things client behavior, and the supporting analysis/output helpers those commands rely on
- raise source-only Swift Testing coverage above the project target and sync CLI help, shell completions, README, changelog, and `docs/` with the expanded command surface

## Validation
- `swift test`
- `swift test --enable-code-coverage`
- `swift build -c release`
- `bash scripts/release-docs-check.sh`

## Notes
- source-only coverage is 87.12% (`5321 / 6108` lines in `Sources/`)
- this PR also includes the command reference, testing/coverage guide, and the productivity-suite design/plan docs under `docs/`
