### PR TITLE
[codex] Fix JXABridge CI test when Things 3 is unavailable

### DIFF
--- a/Tests/ClingsCoreTests/ThingsClient/JXABridgeTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/JXABridgeTests.swift
@@ -153,12 +153,20 @@ struct JXABridgeTests {
 
         let expectedOutput = try await bridge.execute("""
         (() => {
-            const app = Application('Things3');
-            return app.running();
+            try {
+                const app = Application('Things3');
+                return app.running();
+            } catch (error) {
+                return '__missing__';
+            }
         })()
         """)
         let isRunning = await bridge.isThingsRunning()
 
-        #expect(isRunning == (expectedOutput.lowercased() == "true"))
+        if expectedOutput == "__missing__" {
+            #expect(isRunning == false)
+        } else {
+            #expect(isRunning == (expectedOutput.lowercased() == "true"))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make the JXABridge CI test tolerate runners where Things 3 is not installed
- keep verifying `/usr/bin/osascript` execution and `isThingsRunning()` behavior without assuming the app exists

## Root cause
`executeAppleScriptAndRunningCheckUseSystemOsaScript()` directly evaluated `Application('Things3').running()`. On GitHub-hosted macOS runners, Things 3 is not installed, so `osascript` returned "Application can't be found" and the test failed even though production code already treats that condition as `false`.

## Validation
- `/usr/bin/osascript -l JavaScript -e "(() => { try { const app = Application('DefinitelyMissingClingsTestApp'); return app.running(); } catch (error) { return '__missing__'; } })()"`
- `swift test --filter JXABridgeTests/executeAppleScriptAndRunningCheckUseSystemOsaScript`
- `swift test`
- `swift build`
- `swift build -c release`
