### PR TITLE
Allow database path to be passed for initialization + fix 'Today' query

### DIFF
--- a/Sources/ClingsCore/ThingsClient/HybridThingsClient.swift
+++ b/Sources/ClingsCore/ThingsClient/HybridThingsClient.swift
@@ -15,6 +15,11 @@ public final class HybridThingsClient: ThingsClientProtocol, @unchecked Sendable
         self.jxaBridge = JXABridge()
     }
 
+    public init(databasePath: String, bridge: any JXAExecuting = JXABridge()) {
+        self.database = ThingsDatabase(dbPath: databasePath)
+        self.jxaBridge = bridge
+    }
+
     init(database: any ThingsDatabaseReadable, jxaBridge: any JXAExecuting) {
         self.database = database
         self.jxaBridge = jxaBridge

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -89,12 +89,14 @@ public final class ThingsDatabase: Sendable {
                            userModificationDate, project, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0
-                          -- Issue #5: avoid pulling entire anytime backlog.
-                          -- https://github.com/dan-hart/clings/issues/5
-                          AND start = 1 AND startDate = ?
+                          AND (
+                              (start = 1 AND startDate IS NOT NULL)
+                              OR (start = 2 AND startDate IS NOT NULL AND startDate <= ?)
+                              OR (startDate IS NULL AND deadline IS NOT NULL AND deadline <= ? AND deadlineSuppressionDate IS NULL)
+                          )
                     ORDER BY todayIndex, "index"
                     """
-                arguments = [todayCode]
+                arguments = [todayCode, todayCode]
 
             case .upcoming:
                 let todayCode = thingsDateCode(Date())

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -48,8 +48,8 @@ public final class ThingsDatabase: Sendable {
         self.dbPath = path
     }
 
-    /// Initialize with an explicit database path (used by tests).
-    init(dbPath: String) {
+    /// Initialize with an explicit database path.
+    public init(dbPath: String) {
         self.dbPath = dbPath
     }
 

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -90,13 +90,13 @@ public final class ThingsDatabase: Sendable {
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0
                           AND (
-                              (start = 1 AND startDate IS NOT NULL)
+                              (start = 1 AND startDate IS NOT NULL AND startDate <= ?)
                               OR (start = 2 AND startDate IS NOT NULL AND startDate <= ?)
                               OR (startDate IS NULL AND deadline IS NOT NULL AND deadline <= ? AND deadlineSuppressionDate IS NULL)
                           )
-                    ORDER BY todayIndex, "index"
+                    ORDER BY todayIndex IS NULL, todayIndex, "index"
                     """
-                arguments = [todayCode, todayCode]
+                arguments = [todayCode, todayCode, todayCode]
 
             case .upcoming:
                 let todayCode = thingsDateCode(Date())

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
@@ -11,8 +11,8 @@ import Testing
 /// Regression coverage for https://github.com/dan-hart/clings/issues/5
 @Suite("ThingsDatabase")
 struct ThingsDatabaseTests {
-    @Test("Today list includes regular scheduled tasks with a start date")
-    func todayListIncludesRegularScheduledTasks() throws {
+    @Test("Today list includes start=1 tasks on or before today")
+    func todayListIncludesCurrentAndOverdueStartOneTasks() throws {
         let fixture = try makeFixtureDatabase()
 
         let todayCode = thingsDateCode(Date())
@@ -31,7 +31,7 @@ struct ThingsDatabaseTests {
         let todoIDs = Set(try database.fetchList(.today).map(\.id))
         #expect(todoIDs.contains("today-task"))
         #expect(todoIDs.contains("yesterday-task"))
-        #expect(todoIDs.contains("tomorrow-task"))
+        #expect(!todoIDs.contains("tomorrow-task"))
         #expect(!todoIDs.contains("no-date-task"))
         #expect(todoIDs.contains("start-two-today"))
     }
@@ -58,6 +58,59 @@ struct ThingsDatabaseTests {
         #expect(!todoIDs.contains("scheduled-tomorrow"))
         #expect(todoIDs.contains("overdue-deadline"))
         #expect(!todoIDs.contains("suppressed-deadline"))
+    }
+
+    @Test("Today list keeps manual Today ordering ahead of null todayIndex rows")
+    func todayListOrdersNullTodayIndexAfterManualTodayItems() throws {
+        let fixture = try makeFixtureDatabase()
+
+        let todayCode = thingsDateCode(Date())
+        let yesterdayCode = todayCode - 128
+
+        try fixture.db.write { db in
+            try insertTask(
+                db,
+                id: "manual-first",
+                title: "Manual First",
+                start: 1,
+                startDate: todayCode,
+                index: 10,
+                todayIndex: 0
+            )
+            try insertTask(
+                db,
+                id: "manual-second",
+                title: "Manual Second",
+                start: 1,
+                startDate: todayCode,
+                index: 11,
+                todayIndex: 1
+            )
+            try insertTask(
+                db,
+                id: "scheduled-yesterday",
+                title: "Scheduled Yesterday",
+                start: 2,
+                startDate: yesterdayCode,
+                index: 0,
+                todayIndex: nil
+            )
+            try insertTask(
+                db,
+                id: "overdue-deadline",
+                title: "Overdue Deadline",
+                start: 0,
+                startDate: nil,
+                index: 1,
+                deadline: yesterdayCode,
+                todayIndex: nil
+            )
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let todoIDs = try database.fetchList(.today).map(\.id)
+
+        #expect(todoIDs == ["manual-first", "manual-second", "scheduled-yesterday", "overdue-deadline"])
     }
 
     @Test("Issue #5: anytime list uses packed Things date format")
@@ -318,6 +371,7 @@ struct ThingsDatabaseTests {
         notes: String? = nil,
         deadline: Int? = nil,
         deadlineSuppressionDate: Int? = nil,
+        todayIndex: Int? = 0,
         creationDate: Double = 0,
         modificationDate: Double? = nil,
         project: String? = nil,
@@ -328,7 +382,7 @@ struct ThingsDatabaseTests {
                 INSERT INTO TMTask (
                     uuid, title, notes, status, stopDate, deadline, deadlineSuppressionDate, creationDate, userModificationDate,
                     project, area, trashed, type, start, startDate, todayIndex, "index"
-                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
             arguments: [
                 id,
@@ -345,6 +399,7 @@ struct ThingsDatabaseTests {
                 type,
                 start,
                 startDate,
+                todayIndex,
                 index,
             ]
         )

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
@@ -11,8 +11,8 @@ import Testing
 /// Regression coverage for https://github.com/dan-hart/clings/issues/5
 @Suite("ThingsDatabase")
 struct ThingsDatabaseTests {
-    @Test("Issue #5: today list excludes non-today start=1 tasks")
-    func todayListExcludesNonTodayStartTasks() throws {
+    @Test("Today list includes regular scheduled tasks with a start date")
+    func todayListIncludesRegularScheduledTasks() throws {
         let fixture = try makeFixtureDatabase()
 
         let todayCode = thingsDateCode(Date())
@@ -29,7 +29,35 @@ struct ThingsDatabaseTests {
 
         let database = ThingsDatabase(dbPath: fixture.path)
         let todoIDs = Set(try database.fetchList(.today).map(\.id))
-        #expect(todoIDs == ["today-task"])
+        #expect(todoIDs.contains("today-task"))
+        #expect(todoIDs.contains("yesterday-task"))
+        #expect(todoIDs.contains("tomorrow-task"))
+        #expect(!todoIDs.contains("no-date-task"))
+        #expect(todoIDs.contains("start-two-today"))
+    }
+
+    @Test("Today list includes unconfirmed and overdue tasks")
+    func todayListIncludesUnconfirmedAndOverdueTasks() throws {
+        let fixture = try makeFixtureDatabase()
+
+        let todayCode = thingsDateCode(Date())
+        let yesterdayCode = todayCode - 128
+        let tomorrowCode = todayCode + 128
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "scheduled-yesterday", title: "Scheduled Yesterday", start: 2, startDate: yesterdayCode, index: 0)
+            try insertTask(db, id: "scheduled-tomorrow", title: "Scheduled Tomorrow", start: 2, startDate: tomorrowCode, index: 1)
+            try insertTask(db, id: "overdue-deadline", title: "Overdue Deadline", start: 0, startDate: nil, index: 2, deadline: yesterdayCode)
+            try insertTask(db, id: "suppressed-deadline", title: "Suppressed Deadline", start: 0, startDate: nil, index: 3, deadline: yesterdayCode, deadlineSuppressionDate: todayCode)
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let todoIDs = Set(try database.fetchList(.today).map(\.id))
+
+        #expect(todoIDs.contains("scheduled-yesterday"))
+        #expect(!todoIDs.contains("scheduled-tomorrow"))
+        #expect(todoIDs.contains("overdue-deadline"))
+        #expect(!todoIDs.contains("suppressed-deadline"))
     }
 
     @Test("Issue #5: anytime list uses packed Things date format")
@@ -234,6 +262,7 @@ struct ThingsDatabaseTests {
                         status INTEGER NOT NULL,
                         stopDate REAL,
                         deadline INTEGER,
+                        deadlineSuppressionDate INTEGER,
                         creationDate REAL NOT NULL,
                         userModificationDate REAL NOT NULL,
                         project TEXT,
@@ -288,6 +317,7 @@ struct ThingsDatabaseTests {
         type: Int = 0,
         notes: String? = nil,
         deadline: Int? = nil,
+        deadlineSuppressionDate: Int? = nil,
         creationDate: Double = 0,
         modificationDate: Double? = nil,
         project: String? = nil,
@@ -296,9 +326,9 @@ struct ThingsDatabaseTests {
         try db.execute(
             sql: """
                 INSERT INTO TMTask (
-                    uuid, title, notes, status, stopDate, deadline, creationDate, userModificationDate,
+                    uuid, title, notes, status, stopDate, deadline, deadlineSuppressionDate, creationDate, userModificationDate,
                     project, area, trashed, type, start, startDate, todayIndex, "index"
-                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
                 """,
             arguments: [
                 id,
@@ -306,6 +336,7 @@ struct ThingsDatabaseTests {
                 notes,
                 status,
                 deadline,
+                deadlineSuppressionDate,
                 creationDate,
                 modificationDate ?? creationDate,
                 project,


### PR DESCRIPTION
Hello 👋 ,

I have been planning to use `ClingsCore` in a personal project and have identified a few improvements which I've been using in my fork and perhaps you'd like to have them upstream.

## Summary

  This PR improves database-backed Things reads in two areas:

  - allow `ThingsDatabase` and `HybridThingsClient` to be initialized with an explicit database path
  - expand the Today query to include overdue scheduled tasks and applicable deadline-based tasks

  ## Details

  The new explicit database-path initializers make it easier for tests and downstream callers to target a specific Things database without relying on the default lookup path.

  The Today list query now better matches Things behavior by including:

  - scheduled tasks with a start date
  - overdue unconfirmed tasks
  - overdue deadline-based tasks that are not suppressed

  Regression tests were added to cover the updated Today-list behavior, including deadline suppression handling.