### PR TITLE
fix: exclude recurring templates and trashed-project descendants from lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Trashed project descendants**: Todos filed (directly, or via a heading) under a trashed project are now excluded from every list except Trash, matching Things' own behavior. Previously only a todo's own `trashed` flag was checked, so items under a trashed project kept appearing everywhere.
 - **`someday` vs. a concrete start date**: The `someday` list now excludes todos that also carry a `startDate`, matching how Things itself buckets them (under Anytime/Upcoming instead of Someday).
 - **Project resolution through headings**: Todos filed under a heading (rather than directly under a project) now correctly resolve their parent project instead of reporting no project.
+- **Untitled todos rendered as a blank line**: `TextOutputFormatter` now renders todos with an empty title as `(no title)` in both list and detail views, instead of a bare checkbox with nothing after it.
 
 ## [0.3.1] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`someday`/`anytime`/etc. list drift from Things**: `ThingsDatabase` list queries (`fetchList`, `search`) no longer include Things' internal repeating-task templates, which are hidden generator rows (identified by a non-null `rt1_recurrenceRule`) rather than real todos.
+- **Deadline decoding**: `deadline` values are now decoded using Things' packed date format (`(year << 16) | (month << 12) | (day << 7)`) instead of being misread as raw seconds since the Cocoa reference date. The previous decoding produced a nonsensical shared date (e.g. April 23, 2009) for every todo carrying Things' year-4001 "no real deadline" sentinel; that sentinel now correctly decodes to `nil`.
+- **Trashed project descendants**: Todos filed (directly, or via a heading) under a trashed project are now excluded from every list except Trash, matching Things' own behavior. Previously only a todo's own `trashed` flag was checked, so items under a trashed project kept appearing everywhere.
+- **`someday` vs. a concrete start date**: The `someday` list now excludes todos that also carry a `startDate`, matching how Things itself buckets them (under Anytime/Upcoming instead of Someday).
+- **Project resolution through headings**: Todos filed under a heading (rather than directly under a project) now correctly resolve their parent project instead of reporting no project.
+
 ## [0.3.1] - 2026-07-09
 
 ### Added

--- a/Sources/ClingsCore/Models/Todo.swift
+++ b/Sources/ClingsCore/Models/Todo.swift
@@ -91,9 +91,11 @@ public struct Todo: Codable, Identifiable, Equatable, Hashable, Sendable {
     public var isOpen: Bool { status == .open }
 
     /// Whether the task is overdue (has a due date in the past and is still open).
+    /// Compared at calendar-day granularity, since due dates are date-only:
+    /// a task due today is not overdue until tomorrow.
     public var isOverdue: Bool {
         guard status == .open, let dueDate = dueDate else { return false }
-        return dueDate < Date()
+        return dueDate < Calendar.current.startOfDay(for: Date())
     }
 
     /// Human-readable summary for display.

--- a/Sources/ClingsCore/Output/OutputFormatter.swift
+++ b/Sources/ClingsCore/Output/OutputFormatter.swift
@@ -152,7 +152,11 @@ public struct TextOutputFormatter: OutputFormatter {
         var lines: [String] = []
 
         // Title
-        lines.append(bold(todo.name))
+        if todo.name.isEmpty {
+            lines.append(dim("(no title)"))
+        } else {
+            lines.append(bold(todo.name))
+        }
 
         // Status and dates
         var metaLine = "Status: \(statusColor(todo.status))"
@@ -229,7 +233,9 @@ public struct TextOutputFormatter: OutputFormatter {
 
         // Name
         var name = todo.name
-        if todo.status == .completed || todo.status == .canceled {
+        if name.isEmpty {
+            name = dim("(no title)")
+        } else if todo.status == .completed || todo.status == .canceled {
             name = strikethrough(name)
         }
         parts.append(name)

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -187,6 +187,7 @@ public final class ThingsDatabase: Sendable {
                 SELECT uuid, title, notes, status, stopDate, deadline, creationDate, area
                 FROM TMTask
                 WHERE type = 1 AND trashed = 0 AND status = 0
+                      AND rt1_recurrenceRule IS NULL
                 ORDER BY "index"
                 """
 
@@ -288,8 +289,15 @@ public final class ThingsDatabase: Sendable {
 
             let pattern = "%\(query)%"
             let rows = try Row.fetchAll(db, sql: sql, arguments: [pattern, pattern])
-            return try rows.map { row in
-                try self.todoFromRow(row, db: db)
+            return try rows.compactMap { row -> Todo? in
+                // Mirror fetchList: descendants of a trashed project stay hidden
+                // even though their own `trashed` flag is 0.
+                let projectUuid: String? = row["project"]
+                let headingUuid: String? = row["heading"]
+                if try self.isAncestorProjectTrashed(projectUuid: projectUuid, headingUuid: headingUuid, db: db) {
+                    return nil
+                }
+                return try self.todoFromRow(row, db: db)
             }
         }
     }
@@ -436,8 +444,12 @@ public final class ThingsDatabase: Sendable {
 
     /// Encode a local calendar day using Things' packed integer date format.
     /// Format: `(year << 16) | (month << 12) | (day << 7)`.
+    /// Things always packs/unpacks these dates using the Gregorian calendar,
+    /// regardless of the user's preferred calendar (Buddhist, Hebrew, Persian,
+    /// etc.), since the bit fields encode a fixed Gregorian year/month/day.
     private func thingsDateCode(_ date: Date) -> Int {
-        let calendar = Calendar.current
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         let year = components.year ?? 0
         let month = components.month ?? 0
@@ -466,7 +478,10 @@ public final class ThingsDatabase: Sendable {
         components.year = year
         components.month = month
         components.day = day
-        return Calendar.current.date(from: components)
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
+        return calendar.date(from: components)
     }
 }
 

--- a/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
+++ b/Sources/ClingsCore/ThingsClient/ThingsDatabase.swift
@@ -74,10 +74,11 @@ public final class ThingsDatabase: Sendable {
             case .inbox:
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0
                           AND start = 0 AND project IS NULL AND startDate IS NULL
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY "index"
                     """
                 arguments = []
@@ -86,9 +87,10 @@ public final class ThingsDatabase: Sendable {
                 let todayCode = thingsDateCode(Date())
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0
+                          AND rt1_recurrenceRule IS NULL
                           AND (
                               (start = 1 AND startDate IS NOT NULL AND startDate <= ?)
                               OR (start = 2 AND startDate IS NOT NULL AND startDate <= ?)
@@ -102,9 +104,10 @@ public final class ThingsDatabase: Sendable {
                 let todayCode = thingsDateCode(Date())
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0 AND startDate > ?
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY startDate, "index"
                     """
                 arguments = [todayCode]
@@ -113,10 +116,11 @@ public final class ThingsDatabase: Sendable {
                 let todayCode = thingsDateCode(Date())
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0 AND start = 1
                           AND (startDate IS NULL OR startDate <= ?)
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY "index"
                     """
                 arguments = [todayCode]
@@ -124,9 +128,11 @@ public final class ThingsDatabase: Sendable {
             case .someday:
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 0 AND trashed = 0 AND type = 0 AND start = 2
+                          AND startDate IS NULL
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY "index"
                     """
                 arguments = []
@@ -134,9 +140,10 @@ public final class ThingsDatabase: Sendable {
             case .logbook:
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE status = 3 AND trashed = 0 AND type = 0
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY stopDate DESC
                     LIMIT 500
                     """
@@ -145,17 +152,28 @@ public final class ThingsDatabase: Sendable {
             case .trash:
                 sql = """
                     SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                           userModificationDate, project, area
+                           userModificationDate, project, heading, area
                     FROM TMTask
                     WHERE trashed = 1 AND type = 0
+                          AND rt1_recurrenceRule IS NULL
                     ORDER BY "index"
                     """
                 arguments = []
             }
 
             let rows = try Row.fetchAll(db, sql: sql, arguments: arguments)
-            return try rows.map { row in
-                try self.todoFromRow(row, db: db)
+            return try rows.compactMap { row -> Todo? in
+                // Things hides descendants of a trashed project from every list
+                // (except Trash itself), even though the descendant's own
+                // `trashed` flag stays 0. Mirror that here.
+                if list != .trash {
+                    let projectUuid: String? = row["project"]
+                    let headingUuid: String? = row["heading"]
+                    if try self.isAncestorProjectTrashed(projectUuid: projectUuid, headingUuid: headingUuid, db: db) {
+                        return nil
+                    }
+                }
+                return try self.todoFromRow(row, db: db)
             }
         }
     }
@@ -183,9 +201,7 @@ public final class ThingsDatabase: Sendable {
                 let area: Area? = try areaUuid.flatMap { try self.fetchArea(uuid: $0, db: db) }
                 let tags = try self.fetchTagsForTask(uuid: uuid, db: db)
 
-                let deadline: Date? = (row["deadline"] as Int?).flatMap {
-                    Date(timeIntervalSinceReferenceDate: TimeInterval($0))
-                }
+                let deadline = self.decodeDeadline(row["deadline"] as Int?)
                 let creationDate = Date(timeIntervalSinceReferenceDate: TimeInterval(row["creationDate"] as Int))
 
                 return Project(
@@ -241,7 +257,7 @@ public final class ThingsDatabase: Sendable {
         return try db.read { db in
             let sql = """
                 SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                       userModificationDate, project, area
+                       userModificationDate, project, heading, area
                 FROM TMTask
                 WHERE uuid = ? AND type = 0
                 """
@@ -261,9 +277,10 @@ public final class ThingsDatabase: Sendable {
         return try db.read { db in
             let sql = """
                 SELECT uuid, title, notes, status, stopDate, deadline, creationDate,
-                       userModificationDate, project, area
+                       userModificationDate, project, heading, area
                 FROM TMTask
                 WHERE type = 0 AND trashed = 0
+                      AND rt1_recurrenceRule IS NULL
                       AND (title LIKE ? OR notes LIKE ?)
                 ORDER BY todayIndex, "index"
                 LIMIT 100
@@ -285,16 +302,21 @@ public final class ThingsDatabase: Sendable {
         let notes: String? = row["notes"]
         let statusInt: Int = row["status"]
         let projectUuid: String? = row["project"]
+        let headingUuid: String? = row["heading"]
         let areaUuid: String? = row["area"]
 
-        let project: Project? = try projectUuid.flatMap { try self.fetchProjectBasic(uuid: $0, db: db) }
+        // A todo filed under a heading has `project` left blank; the real
+        // parent project lives on the heading row instead.
+        let resolvedProjectUuid = try projectUuid ?? headingUuid.flatMap {
+            try self.projectUuid(forHeading: $0, db: db)
+        }
+
+        let project: Project? = try resolvedProjectUuid.flatMap { try self.fetchProjectBasic(uuid: $0, db: db) }
         let area: Area? = try areaUuid.flatMap { try self.fetchArea(uuid: $0, db: db) }
         let tags = try fetchTagsForTask(uuid: uuid, db: db)
         let checklistItems = try fetchChecklistItems(uuid: uuid, db: db)
 
-        let deadline: Date? = (row["deadline"] as Int?).flatMap {
-            Date(timeIntervalSinceReferenceDate: TimeInterval($0))
-        }
+        let deadline = decodeDeadline(row["deadline"] as Int?)
         let creationDate: Date = (row["creationDate"] as Double?).flatMap {
             Date(timeIntervalSinceReferenceDate: $0)
         } ?? Date()
@@ -333,6 +355,26 @@ public final class ThingsDatabase: Sendable {
             dueDate: nil,
             creationDate: Date()
         )
+    }
+
+    /// Resolve the project a heading belongs to.
+    private func projectUuid(forHeading headingUuid: String, db: Database) throws -> String? {
+        let sql = "SELECT project FROM TMTask WHERE uuid = ? AND type = 2"
+        return try Row.fetchOne(db, sql: sql, arguments: [headingUuid])?["project"]
+    }
+
+    /// Whether a todo's ancestor project (direct, or via a heading) is trashed.
+    /// Things hides descendants of a trashed project from every list even
+    /// though the descendant's own `trashed` column stays 0.
+    private func isAncestorProjectTrashed(projectUuid: String?, headingUuid: String?, db: Database) throws -> Bool {
+        let resolvedProjectUuid = try projectUuid ?? headingUuid.flatMap {
+            try self.projectUuid(forHeading: $0, db: db)
+        }
+        guard let resolvedProjectUuid else { return false }
+
+        let sql = "SELECT trashed FROM TMTask WHERE uuid = ? AND type = 1"
+        guard let row = try Row.fetchOne(db, sql: sql, arguments: [resolvedProjectUuid]) else { return false }
+        return (row["trashed"] as Int) == 1
     }
 
     private func fetchArea(uuid: String, db: Database) throws -> Area? {
@@ -401,6 +443,30 @@ public final class ThingsDatabase: Sendable {
         let month = components.month ?? 0
         let day = components.day ?? 0
         return (year << 16) | (month << 12) | (day << 7)
+    }
+
+    /// Decode a `deadline` value stored using Things' packed integer date
+    /// format (see `thingsDateCode`). Things uses year 4001 as an internal
+    /// sentinel for "no real deadline" (visible via AppleScript as
+    /// `January 1, 4001`), which is not a real date to surface to users.
+    ///
+    /// Note this is a date-only value (no time component); it was previously
+    /// misdecoded as raw seconds since the Cocoa reference date, which
+    /// produced nonsensical dates like April 23, 2009 for every task sharing
+    /// that sentinel.
+    private func decodeDeadline(_ value: Int?) -> Date? {
+        guard let value else { return nil }
+
+        let year = value >> 16
+        let month = (value >> 12) & 0xF
+        let day = (value >> 7) & 0x1F
+        guard year > 0, year < 4001, month > 0, day > 0 else { return nil }
+
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        return Calendar.current.date(from: components)
     }
 }
 

--- a/Tests/ClingsCoreTests/Models/TodoTests.swift
+++ b/Tests/ClingsCoreTests/Models/TodoTests.swift
@@ -108,6 +108,14 @@ struct TodoTests {
             #expect(!todo.isOverdue)
         }
 
+        @Test func isNotOverdueWhenDueDateIsToday() {
+            // Deadlines are date-only (local midnight). A task due "today"
+            // must not read as overdue merely because midnight has passed.
+            let todayMidnight = Calendar.current.startOfDay(for: Date())
+            let todo = Todo(id: "t1", name: "Due Today", status: .open, dueDate: todayMidnight)
+            #expect(!todo.isOverdue)
+        }
+
         @Test func summaryWithProjectAndTags() {
             let project = Project(id: "p1", name: "MyProject")
             let tag1 = Tag(name: "work")

--- a/Tests/ClingsCoreTests/Output/OutputFormatterTests.swift
+++ b/Tests/ClingsCoreTests/Output/OutputFormatterTests.swift
@@ -193,6 +193,19 @@ struct OutputFormatterTests {
             #expect(output.contains("Project Beta"))
         }
 
+        @Test("Todos with an empty title render a placeholder instead of a blank line")
+        func formatTodoWithEmptyTitle() {
+            let formatter = TextOutputFormatter(useColors: false)
+            let untitled = Todo(id: "untitled-1", name: "")
+
+            let listOutput = formatter.format(todos: [untitled])
+            #expect(listOutput.contains("(no title)"))
+            #expect(listOutput.contains("☐"))
+
+            let detailOutput = formatter.format(todo: untitled)
+            #expect(detailOutput.contains("(no title)"))
+        }
+
         @Test func formatEmptyProjects() {
             let formatter = TextOutputFormatter(useColors: false)
             let output = formatter.format(projects: [])

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
@@ -208,8 +208,33 @@ struct ThingsDatabaseTests {
         #expect(projects[0].notes == "Project notes")
         #expect(projects[0].area?.name == "Work")
         #expect(projects[0].tags.map(\.name) == ["docs"])
-        #expect(projects[0].dueDate == Calendar.current.date(from: deadlineComponents))
+        #expect(projects[0].dueDate == gregorianDate(from: deadlineComponents))
         #expect(projects[0].creationDate == Date(timeIntervalSinceReferenceDate: TimeInterval(createdAt)))
+    }
+
+    @Test("fetchProjects excludes repeating-project templates")
+    func fetchProjectsExcludesRecurrenceTemplates() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertTask(
+                db,
+                id: "recurring-project-template",
+                title: "Weekly Review",
+                start: 0,
+                startDate: nil,
+                index: 0,
+                type: 1,
+                recurrenceRule: "<plist/>"
+            )
+            try insertTask(db, id: "real-project", title: "Real Project", start: 0, startDate: nil, index: 1, type: 1)
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let projectIDs = Set(try database.fetchProjects().map(\.id))
+
+        #expect(!projectIDs.contains("recurring-project-template"))
+        #expect(projectIDs.contains("real-project"))
     }
 
     @Test func fetchAreasAndTagsReturnAttachedMetadata() throws {
@@ -288,7 +313,7 @@ struct ThingsDatabaseTests {
         #expect(todo.tags.map(\.name) == ["docs"])
         #expect(todo.checklistItems.map(\.name) == ["Draft outline", "Publish examples"])
         #expect(todo.checklistItems.map(\.completed) == [true, false])
-        #expect(todo.dueDate == Calendar.current.date(from: deadlineComponents))
+        #expect(todo.dueDate == gregorianDate(from: deadlineComponents))
         #expect(todo.creationDate == Date(timeIntervalSinceReferenceDate: 100))
         #expect(todo.modificationDate == Date(timeIntervalSinceReferenceDate: 200))
         #expect(searchResults.map(\.id) == ["todo-1"])
@@ -397,6 +422,26 @@ struct ThingsDatabaseTests {
         let todo = try database.fetchTodo(id: "todo-under-heading")
 
         #expect(todo.project?.id == "live-project")
+    }
+
+    @Test("Search excludes todos whose ancestor project is trashed, even directly or via a heading")
+    func searchExcludesDescendantsOfTrashedProjects() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "live-project", title: "Live Project", start: 0, startDate: nil, index: 0, type: 1)
+            try insertTask(db, id: "trashed-project", title: "Trashed Project", start: 0, startDate: nil, index: 1, trashed: 1, type: 1)
+            try insertTask(db, id: "heading-in-trashed-project", title: "Heading", start: 0, startDate: nil, index: 2, type: 2, project: "trashed-project")
+
+            try insertTask(db, id: "task-in-live-project", title: "Findable Task", start: 2, startDate: nil, index: 3, project: "live-project")
+            try insertTask(db, id: "task-in-trashed-project", title: "Findable Task", start: 2, startDate: nil, index: 4, project: "trashed-project")
+            try insertTask(db, id: "task-under-trashed-heading", title: "Findable Task", start: 2, startDate: nil, index: 5, heading: "heading-in-trashed-project")
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let resultIDs = Set(try database.search(query: "Findable").map(\.id))
+
+        #expect(resultIDs == ["task-in-live-project"])
     }
 
     @Test func fetchTodoThrowsNotFoundForUnknownID() throws {
@@ -541,12 +586,23 @@ struct ThingsDatabaseTests {
     }
 
     /// Things packs local date components into an integer: yyyyMMMMdd0000000.
+    /// Things always packs/unpacks these dates using the Gregorian calendar,
+    /// independent of the test machine's preferred `Calendar.current`.
     private func thingsDateCode(_ date: Date) -> Int {
-        let calendar = Calendar.current
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         let year = components.year ?? 0
         let month = components.month ?? 0
         let day = components.day ?? 0
         return (year << 16) | (month << 12) | (day << 7)
+    }
+
+    /// Independent of the test machine's preferred `Calendar.current`, matching
+    /// the Gregorian calendar ThingsDatabase uses to decode packed dates.
+    private func gregorianDate(from components: DateComponents) -> Date? {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone.current
+        return calendar.date(from: components)
     }
 }

--- a/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
+++ b/Tests/ClingsCoreTests/ThingsClient/ThingsDatabaseTests.swift
@@ -176,7 +176,8 @@ struct ThingsDatabaseTests {
 
     @Test func fetchProjectsIncludesAreaTagsAndDates() throws {
         let fixture = try makeFixtureDatabase()
-        let deadline = 1_234
+        let deadlineComponents = DateComponents(year: 2030, month: 6, day: 15)
+        let deadline = (2030 << 16) | (6 << 12) | (15 << 7)
         let createdAt = 4_567.0
 
         try fixture.db.write { db in
@@ -207,7 +208,7 @@ struct ThingsDatabaseTests {
         #expect(projects[0].notes == "Project notes")
         #expect(projects[0].area?.name == "Work")
         #expect(projects[0].tags.map(\.name) == ["docs"])
-        #expect(projects[0].dueDate == Date(timeIntervalSinceReferenceDate: TimeInterval(deadline)))
+        #expect(projects[0].dueDate == Calendar.current.date(from: deadlineComponents))
         #expect(projects[0].creationDate == Date(timeIntervalSinceReferenceDate: TimeInterval(createdAt)))
     }
 
@@ -236,6 +237,8 @@ struct ThingsDatabaseTests {
 
     @Test func fetchTodoAndSearchReturnRichTodoMetadata() throws {
         let fixture = try makeFixtureDatabase()
+        let deadlineComponents = DateComponents(year: 2030, month: 1, day: 2)
+        let deadline = (2030 << 16) | (1 << 12) | (2 << 7)
 
         try fixture.db.write { db in
             try insertArea(db, id: "area-work", title: "Work", index: 0)
@@ -257,7 +260,7 @@ struct ThingsDatabaseTests {
                 startDate: thingsDateCode(Date()),
                 index: 1,
                 notes: "Coordinate release notes",
-                deadline: 900,
+                deadline: deadline,
                 creationDate: 100,
                 modificationDate: 200,
                 project: "project-1",
@@ -285,10 +288,115 @@ struct ThingsDatabaseTests {
         #expect(todo.tags.map(\.name) == ["docs"])
         #expect(todo.checklistItems.map(\.name) == ["Draft outline", "Publish examples"])
         #expect(todo.checklistItems.map(\.completed) == [true, false])
-        #expect(todo.dueDate == Date(timeIntervalSinceReferenceDate: 900))
+        #expect(todo.dueDate == Calendar.current.date(from: deadlineComponents))
         #expect(todo.creationDate == Date(timeIntervalSinceReferenceDate: 100))
         #expect(todo.modificationDate == Date(timeIntervalSinceReferenceDate: 200))
         #expect(searchResults.map(\.id) == ["todo-1"])
+    }
+
+    @Test("Deadline sentinel (Things year 4001, \"no real deadline\") decodes to nil")
+    func deadlineSentinelDecodesToNoDueDate() throws {
+        let fixture = try makeFixtureDatabase()
+        let sentinelCode = (4001 << 16) | (1 << 12) | (1 << 7)
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "no-real-deadline", title: "No Real Deadline", start: 0, startDate: nil, index: 0, deadline: sentinelCode)
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let todo = try database.fetchTodo(id: "no-real-deadline")
+        #expect(todo.dueDate == nil)
+    }
+
+    @Test("List queries exclude repeating-task templates")
+    func listQueriesExcludeRecurrenceTemplates() throws {
+        let fixture = try makeFixtureDatabase()
+        let todayCode = thingsDateCode(Date())
+
+        try fixture.db.write { db in
+            try insertTask(
+                db,
+                id: "recurring-template",
+                title: "Pay Mortgage",
+                start: 2,
+                startDate: nil,
+                index: 0,
+                recurrenceRule: "<plist/>"
+            )
+            try insertTask(db, id: "real-someday-task", title: "Real Someday Task", start: 2, startDate: nil, index: 1)
+            try insertTask(
+                db,
+                id: "recurring-anytime-template",
+                title: "Recurring Anytime",
+                start: 1,
+                startDate: todayCode,
+                index: 2,
+                recurrenceRule: "<plist/>"
+            )
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let somedayIDs = Set(try database.fetchList(.someday).map(\.id))
+        let anytimeIDs = Set(try database.fetchList(.anytime).map(\.id))
+
+        #expect(!somedayIDs.contains("recurring-template"))
+        #expect(somedayIDs.contains("real-someday-task"))
+        #expect(!anytimeIDs.contains("recurring-anytime-template"))
+    }
+
+    @Test("Someday list excludes tasks that also carry a concrete start date")
+    func somedayListExcludesTasksWithStartDate() throws {
+        let fixture = try makeFixtureDatabase()
+        let todayCode = thingsDateCode(Date())
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "someday-no-date", title: "Someday No Date", start: 2, startDate: nil, index: 0)
+            try insertTask(db, id: "someday-with-date", title: "Someday With Date", start: 2, startDate: todayCode, index: 1)
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let somedayIDs = Set(try database.fetchList(.someday).map(\.id))
+
+        #expect(somedayIDs.contains("someday-no-date"))
+        #expect(!somedayIDs.contains("someday-with-date"))
+    }
+
+    @Test("List queries exclude todos whose ancestor project is trashed, even directly or via a heading")
+    func listQueriesExcludeDescendantsOfTrashedProjects() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "live-project", title: "Live Project", start: 0, startDate: nil, index: 0, type: 1)
+            try insertTask(db, id: "trashed-project", title: "Trashed Project", start: 0, startDate: nil, index: 1, trashed: 1, type: 1)
+            try insertTask(db, id: "heading-in-trashed-project", title: "Heading", start: 0, startDate: nil, index: 2, type: 2, project: "trashed-project")
+
+            try insertTask(db, id: "task-in-live-project", title: "Task In Live Project", start: 2, startDate: nil, index: 3, project: "live-project")
+            try insertTask(db, id: "task-in-trashed-project", title: "Task In Trashed Project", start: 2, startDate: nil, index: 4, project: "trashed-project")
+            try insertTask(db, id: "task-under-trashed-heading", title: "Task Under Trashed Heading", start: 2, startDate: nil, index: 5, heading: "heading-in-trashed-project")
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let somedayIDs = Set(try database.fetchList(.someday).map(\.id))
+
+        #expect(somedayIDs.contains("task-in-live-project"))
+        #expect(!somedayIDs.contains("task-in-trashed-project"))
+        #expect(!somedayIDs.contains("task-under-trashed-heading"))
+    }
+
+    @Test("A todo filed directly under a heading resolves its project through that heading")
+    func todoUnderHeadingResolvesProjectThroughHeading() throws {
+        let fixture = try makeFixtureDatabase()
+
+        try fixture.db.write { db in
+            try insertTask(db, id: "live-project", title: "Live Project", start: 0, startDate: nil, index: 0, type: 1)
+            try insertTask(db, id: "heading-1", title: "Heading", start: 0, startDate: nil, index: 1, type: 2, project: "live-project")
+            try insertTask(db, id: "todo-under-heading", title: "Todo Under Heading", start: 1, startDate: nil, index: 2, heading: "heading-1")
+        }
+
+        let database = ThingsDatabase(dbPath: fixture.path)
+        let todo = try database.fetchTodo(id: "todo-under-heading")
+
+        #expect(todo.project?.id == "live-project")
     }
 
     @Test func fetchTodoThrowsNotFoundForUnknownID() throws {
@@ -319,12 +427,14 @@ struct ThingsDatabaseTests {
                         creationDate REAL NOT NULL,
                         userModificationDate REAL NOT NULL,
                         project TEXT,
+                        heading TEXT,
                         area TEXT,
                         trashed INTEGER NOT NULL,
                         type INTEGER NOT NULL,
                         start INTEGER,
                         startDate INTEGER,
                         todayIndex INTEGER,
+                        rt1_recurrenceRule TEXT,
                         "index" INTEGER NOT NULL
                         )
                         """
@@ -375,14 +485,16 @@ struct ThingsDatabaseTests {
         creationDate: Double = 0,
         modificationDate: Double? = nil,
         project: String? = nil,
-        area: String? = nil
+        heading: String? = nil,
+        area: String? = nil,
+        recurrenceRule: String? = nil
     ) throws {
         try db.execute(
             sql: """
                 INSERT INTO TMTask (
                     uuid, title, notes, status, stopDate, deadline, deadlineSuppressionDate, creationDate, userModificationDate,
-                    project, area, trashed, type, start, startDate, todayIndex, "index"
-                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    project, heading, area, trashed, type, start, startDate, todayIndex, rt1_recurrenceRule, "index"
+                ) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
             arguments: [
                 id,
@@ -394,12 +506,14 @@ struct ThingsDatabaseTests {
                 creationDate,
                 modificationDate ?? creationDate,
                 project,
+                heading,
                 area,
                 trashed,
                 type,
                 start,
                 startDate,
                 todayIndex,
+                recurrenceRule,
                 index,
             ]
         )


### PR DESCRIPTION
## Summary

`clings someday` was reporting 30 open items on my machine while Things 3's own Someday list showed **zero**. Root-caused it by diffing `clings --json` output against the raw Things SQLite database and Things' own AppleScript dictionary. Three independent bugs compound to cause this (and similarly inflate other lists like `anytime`):

- **Repeating-task templates counted as todos.** Things stores each repeating task as a hidden "template" row (identified by a non-null `rt1_recurrenceRule`) that spawns real instance rows over time. Things never shows templates in any list, but `ThingsDatabase.fetchList`/`search` never filtered them out. In my data, 26 of the 30 phantom `someday` items were templates (e.g. "Pay Mortgage", "Do taxes").
- **Trashed project descendants leak through.** Things hides all descendants of a trashed project from every list, but a descendant's own `trashed` column stays `0`. The old code only checked the todo's own flag, not its ancestor project's (resolved directly or through a heading).
- **`someday` ignored `startDate`.** A todo can have `start = 2` (Someday) but also carry a concrete `startDate`; Things buckets that under Anytime/Upcoming instead. `someday` didn't account for this.

Also fixed a related bug while I was in here: `deadline` was being decoded as raw seconds since the Cocoa reference date, but Things actually packs it as `(year << 16) | (month << 12) | (day << 7)` (same format already used by `thingsDateCode` for query filtering, just not for reading results back). Any todo carrying Things' year-4001 "no real deadline" sentinel was rendering as a bogus shared due date (`2009-04-23T21:09:20Z` for every affected todo) instead of no due date. As a bonus, todos filed under a heading (rather than directly under a project) now correctly resolve their parent project instead of reporting none.

After the fix, on my real database: `someday` 30 → 0 (matches Things exactly), `anytime` 39 → 9 (matches Things' AppleScript count exactly), `today`/`inbox` unchanged and already matching.

## Test plan

- [x] `swift build` — clean build
- [x] Added regression tests to `ThingsDatabaseTests.swift`: recurrence-template exclusion, someday-with-startDate exclusion, trashed-ancestor-project exclusion (direct and via heading), heading→project resolution, and deadline sentinel → `nil`. Updated two existing tests that had asserted the old (buggy) deadline decoding.
- [x] Manually verified against my live Things database + AppleScript ground truth (see summary above)
- [ ] `swift test` — **could not run in my environment**: only Command Line Tools is installed (no Xcode.app), and this toolchain's `import Testing` doesn't resolve, which reproduces on a clean checkout of `main` too (unrelated to this change). Would appreciate CI or a maintainer confirming the suite passes.
